### PR TITLE
Return 400 on invalid /event payloads instead of silent 200

### DIFF
--- a/Sources/DynamicIsland/LocalServer.swift
+++ b/Sources/DynamicIsland/LocalServer.swift
@@ -93,18 +93,75 @@ class LocalServer {
                 // GET /response — hook script polls for user's permission choice
                 self.handleResponsePoll(connection)
             } else if firstLine.contains("/event") {
-                // POST /event — normal event
-                self.sendHTTP(connection, body: "{\"status\":\"ok\"}")
-                if let bodyRange = raw.range(of: "\r\n\r\n") {
-                    let bodyString = String(raw[bodyRange.upperBound...])
-                    if let bodyData = bodyString.data(using: .utf8) {
-                        self.processEvent(bodyData)
+                // POST /event — parse body first so invalid payloads get a
+                // real error response instead of a misleading 200 OK.
+                do {
+                    guard let bodyRange = raw.range(of: "\r\n\r\n") else {
+                        throw EventError.missingBody
                     }
+                    let bodyData = Data(raw[bodyRange.upperBound...].utf8)
+                    guard !bodyData.isEmpty else {
+                        throw EventError.missingBody
+                    }
+                    try self.processEvent(bodyData)
+                    self.sendHTTP(connection, body: "{\"status\":\"ok\"}")
+                } catch {
+                    let eventError = error as? EventError
+                    let code = eventError?.code ?? "internal_error"
+                    let message = eventError?.message ?? "\(error)"
+                    print("[DynamicIsland] /event error [\(code)]: \(message)")
+                    self.sendHTTP(
+                        connection,
+                        body: Self.errorBody(code: code, message: message),
+                        statusCode: "400 Bad Request"
+                    )
                 }
             } else {
                 self.sendHTTP(connection, body: "{\"status\":\"ok\"}")
             }
         }
+    }
+
+    /// Errors surfaced to POST /event callers so a bad payload no longer
+    /// gets swallowed into a silent 200 OK.
+    ///
+    /// `code` is the stable machine-readable identifier; `message` is a
+    /// human-friendly description that may vary by OS version / locale.
+    private enum EventError: Error {
+        case missingBody
+        case invalidJSON(String)
+        case invalidShape(String)
+
+        var code: String {
+            switch self {
+            case .missingBody: return "missing_body"
+            case .invalidJSON: return "invalid_json"
+            case .invalidShape: return "invalid_shape"
+            }
+        }
+
+        var message: String {
+            switch self {
+            case .missingBody: return "missing request body"
+            case .invalidJSON(let reason): return "invalid JSON: \(reason)"
+            case .invalidShape(let reason): return "invalid event shape: \(reason)"
+            }
+        }
+    }
+
+    /// Safely build a JSON error body. Runs fields through JSONSerialization
+    /// so embedded quotes / newlines don't corrupt the response.
+    private static func errorBody(code: String, message: String) -> String {
+        let payload: [String: String] = [
+            "status": "error",
+            "code": code,
+            "message": message,
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: payload),
+           let str = String(data: data, encoding: .utf8) {
+            return str
+        }
+        return "{\"status\":\"error\",\"code\":\"\(code)\"}"
     }
 
     private func sendHTTP(_ connection: NWConnection, body: String, statusCode: String = "200 OK") {
@@ -159,10 +216,15 @@ class LocalServer {
         }
     }
 
-    private func processEvent(_ data: Data) {
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            print("[DynamicIsland] Invalid JSON")
-            return
+    private func processEvent(_ data: Data) throws {
+        let parsed: Any
+        do {
+            parsed = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            throw EventError.invalidJSON(error.localizedDescription)
+        }
+        guard let json = parsed as? [String: Any] else {
+            throw EventError.invalidShape("top-level value must be a JSON object")
         }
 
         let type = json["type"] as? String ?? "custom"


### PR DESCRIPTION
Closes #1

## Summary

`POST /event` currently responds with `200 {"status":"ok"}` before parsing the body. Invalid JSON, non-object JSON, and empty bodies are all silently dropped while the caller sees success — making hook-script misbehavior very hard to debug.

This PR parses the body first. On failure, the server responds with `400 Bad Request` and a structured JSON error body containing a stable machine-readable `code` plus a human-readable `message`.

## Behavior

| Case | Before | After |
|------|--------|-------|
| Valid event | `200 {"status":"ok"}` | `200 {"status":"ok"}` (byte-identical) |
| Invalid JSON | `200 {"status":"ok"}` (silent) | `400 {"status":"error","code":"invalid_json","message":"..."}` |
| Non-object top-level | `200 {"status":"ok"}` (silent) | `400 {"status":"error","code":"invalid_shape","message":"..."}` |
| Missing body | `200 {"status":"ok"}` (silent) | `400 {"status":"error","code":"missing_body","message":"..."}` |
| `/response` & other paths | unchanged | unchanged |

Success path is **byte-identical** to today. The only observable change is on the previously-silent failure paths.

## Impact on existing callers

All in-repo callers post fire-and-forget:

- `hooks/island-hook.sh` — `curl -s ... -d "$payload" > /dev/null 2>&1 &`
- `hooks/claude-hook.sh` — `curl -s ... -d "$1" > /dev/null 2>&1 &`
- `scripts/island-progress.sh` — same pattern

None inspect response body or exit code, so the 400 on malformed payloads is safe for all existing integrations.

## Design notes

- `EventError` enum separates `invalid_json` (syntax) from `invalid_shape` (top-level not an object) so future consumers can branch on stable codes.
- `errorBody(code:message:)` runs fields through `JSONSerialization` to prevent embedded quotes / newlines in error messages from producing invalid JSON responses.
- Body-extraction logic lives inline inside `handleConnection`'s `/event` branch (3 lines) rather than a separate helper, to keep HTTP-parsing details from leaking into a utility function.
- Single `catch` block with inline type-check satisfies Swift 5.9's exhaustive-catch requirement without duplication.

## Validation

Local `swift build -c release` passes, and manual tests confirmed each case:

```bash
# 200
curl -s http://127.0.0.1:9423/event -d '{"title":"OK"}'
# {"status":"ok"}

# 400 invalid_json
curl -s http://127.0.0.1:9423/event -d 'not json'
# {"status":"error","code":"invalid_json","message":"invalid JSON: ..."}

# 400 invalid_shape
curl -s http://127.0.0.1:9423/event -d '[1,2,3]'
# {"status":"error","code":"invalid_shape","message":"invalid event shape: top-level value must be a JSON object"}

# 400 missing_body
curl -s -X POST http://127.0.0.1:9423/event -H "Content-Length: 0"
# {"status":"error","code":"missing_body","message":"missing request body"}
```

## Out of scope (noted for future PRs)

- HTTP parsing still assumes the full request arrives in a single `NWConnection.receive`. For loopback ≤64KB payloads this is fine in practice, but a proper implementation would buffer by `Content-Length`.
- The `/event` branch does not explicitly enforce the `POST` method; a `GET /event` now returns `400 missing_body` (previously `200 {"status":"ok"}`).

Both are pre-existing concerns that this PR does not touch. Happy to address in follow-ups if desired.