### PR TITLE
Auto hook installation for Claude Code and Copilot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,11 +37,33 @@ The app listens on **port 9423** for HTTP POST events.
 
 Project label: derived from `cwd` basename; subagent events override it with `↳ <agent_type>`. A deterministic hash picks one of 8 palette colors so concurrent sessions are visually distinguishable.
 
+### Auto-install (HookInstaller.swift)
+
+Hooks are auto-installed on first launch via an NSAlert (Install / Skip / Never), with the choice persisted in `UserDefaults["hookInstallChoice"]`. Subsequent launches silently sync via `syncIfOutdated`, which is idempotent and only writes when the deployed script or settings actually drift.
+
+The script is deployed to `~/.claude/hooks/dynamic-island-hook.sh` (stable path independent of the .app location), and `~/.claude/settings.json` is updated non-destructively — entries from other tools (gemini-bridge etc.) are preserved by detecting "ours" via command path markers (`dynamic-island-hook` / `island-hook.sh` / `claude-hook.sh` / `DynamicIsland`).
+
+CLI:
+- `--install-hooks` / `--uninstall-hooks` — Claude Code (writes `~/.claude/settings.json`)
+- `--install-copilot-hooks [repoPath]` / `--uninstall-copilot-hooks [repoPath]` — Copilot (writes `{repo}/.github/hooks/hooks.json`, defaults to cwd)
+
+Copilot uses a different schema: top-level `version: 1`, camelCase events (`preToolUse`, `postToolUse`, `userPromptSubmitted`, `sessionStart`, `sessionEnd`, `errorOccurred`), no matcher, fields `{type, bash, timeoutSec}`.
+
+Safety: `writeSettings` refuses to overwrite the file if existing JSON is invalid, to avoid clobbering user config. `currentlyInSync` checks the deployed script exists, not just the settings entries.
+
+### Registered events (Claude Code)
+
+PreToolUse, PostToolUse, PostToolUseFailure, PermissionRequest, PermissionDenied, Notification, Stop, StopFailure, SubagentStart, SubagentStop, UserPromptSubmit, SessionStart, SessionEnd, PreCompact, PostCompact. `PostToolUseFailure` / `StopFailure` replace fragile grep-based error detection; `PreCompact` / `PostCompact` show context compaction progress.
+
 ## Permission Flow
 
 `PermissionRequest` hook POSTs an `action`-style event (Permission title + tool detail), then long-polls `GET /response` for up to 25s. The UI buttons call `LocalServer.setResponse("allow"|"deny")`, which resumes the waiter. If no waiter is present the value is stored in `pendingResponse` for the next poll — but never persisted past a single delivery, to avoid stale clicks leaking into future requests. On timeout the hook exits silently and Claude Code falls back to its normal permission prompt.
 
 The matcher in `settings.json` intentionally limits `PermissionRequest` to risky tools (`Bash|Edit|Write|MultiEdit|NotebookEdit`) — read-only tools like `Read`/`Grep`/`Glob` skip the island so subagents don't spam Allow/Deny.
+
+### FIFO context correlation
+
+`PreToolUse` for Edit/Write/Bash/MultiEdit/NotebookEdit caches its full payload to `/tmp/di_pretool_${PROJECT}.json`. The next `PermissionRequest` reads it to enrich the dialog: Edit/MultiEdit shows a colored diff (red `-` / green `+`), Write shows a content preview, Bash backfills the command/description if `tool_input` arrived empty. Keyed by project name, single-slot (the next PreToolUse overwrites) — works because PreToolUse and PermissionRequest fire serially per Claude session.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -67,67 +67,45 @@ open /Applications/DynamicIsland.app
 
 ## Setup Hooks
 
-啟動 app 後，設定你使用的 AI tool 的 hooks。
+### Claude Code（推薦：自動安裝）
 
-### Claude Code
+第一次啟動 app 時會跳出對話框問你要不要設定 Claude Code hooks。按 **Install** 就好，會自動：
 
-在 `~/.claude/settings.json` 加入（如果已有 `hooks` 區塊，合併進去）：
+- 把 `island-hook.sh` 複製到 `~/.claude/hooks/dynamic-island-hook.sh`
+- 在 `~/.claude/settings.json` 註冊所有 hook 事件
+- 保留你其他工具的 hook（例如 gemini-bridge）不會被動到
 
-```json
-{
-  "hooks": {
-    "PreToolUse": [
-      { "matcher": "", "hooks": [{ "type": "command", "command": "/Applications/DynamicIsland.app/Contents/Resources/island-hook.sh", "timeout": 5 }] }
-    ],
-    "PostToolUse": [
-      { "matcher": "Bash|Edit|Write", "hooks": [{ "type": "command", "command": "/Applications/DynamicIsland.app/Contents/Resources/island-hook.sh", "timeout": 5 }] }
-    ],
-    "Notification": [
-      { "matcher": "", "hooks": [{ "type": "command", "command": "/Applications/DynamicIsland.app/Contents/Resources/island-hook.sh", "timeout": 5 }] }
-    ],
-    "Stop": [
-      { "matcher": "", "hooks": [{ "type": "command", "command": "/Applications/DynamicIsland.app/Contents/Resources/island-hook.sh", "timeout": 5 }] }
-    ],
-    "UserPromptSubmit": [
-      { "matcher": "", "hooks": [{ "type": "command", "command": "/Applications/DynamicIsland.app/Contents/Resources/island-hook.sh", "timeout": 5 }] }
-    ],
-    "SubagentStart": [
-      { "matcher": "", "hooks": [{ "type": "command", "command": "/Applications/DynamicIsland.app/Contents/Resources/island-hook.sh", "timeout": 5 }] }
-    ],
-    "SubagentStop": [
-      { "matcher": "", "hooks": [{ "type": "command", "command": "/Applications/DynamicIsland.app/Contents/Resources/island-hook.sh", "timeout": 5 }] }
-    ],
-    "PermissionRequest": [
-      { "matcher": "Bash|Edit|Write|MultiEdit|NotebookEdit", "hooks": [{ "type": "command", "command": "/Applications/DynamicIsland.app/Contents/Resources/island-hook.sh", "timeout": 30 }] }
-    ]
-  }
-}
-```
+之後升級重新打開 app，hooks 會自動同步到最新版（idempotent，沒變動就不寫）。
 
-> The `PermissionRequest` matcher intentionally excludes read-only tools (`Read`, `Grep`, `Glob`). This avoids Allow/Deny popping up for trivial subagent actions — Claude Code's default permission flow handles them silently.
-
-### GitHub Copilot (VS Code)
-
-複製設定到 `~/.copilot/hooks/hooks.json`：
+也可以從 terminal 手動執行：
 
 ```bash
-mkdir -p ~/.copilot/hooks
-cp /Applications/DynamicIsland.app/Contents/Resources/island-hook.sh ~/.copilot/hooks/
+DynamicIsland --install-hooks       # 安裝 / 升級
+DynamicIsland --uninstall-hooks     # 移除
 ```
 
-然後建立 `~/.copilot/hooks/hooks.json`（或放在 repo 的 `.github/hooks/hooks.json`）：
+> 註冊的事件涵蓋 PreToolUse / PostToolUse / PostToolUseFailure / PermissionRequest / PermissionDenied / Notification / Stop / StopFailure / SubagentStart / SubagentStop / UserPromptSubmit / SessionStart / SessionEnd / PreCompact / PostCompact。`PermissionRequest` matcher 限制在危險工具（`Bash|Edit|Write|MultiEdit|NotebookEdit`），唯讀工具不會跳 Allow/Deny。
 
-```json
-{
-  "hooks": {
-    "PreToolUse": [{ "type": "command", "command": "~/.copilot/hooks/island-hook.sh", "timeout": 5 }],
-    "PostToolUse": [{ "type": "command", "command": "~/.copilot/hooks/island-hook.sh", "timeout": 5 }],
-    "UserPromptSubmit": [{ "type": "command", "command": "~/.copilot/hooks/island-hook.sh", "timeout": 5 }],
-    "Stop": [{ "type": "command", "command": "~/.copilot/hooks/island-hook.sh", "timeout": 5 }],
-    "SessionStart": [{ "type": "command", "command": "~/.copilot/hooks/island-hook.sh", "timeout": 5 }]
-  }
-}
+### GitHub Copilot CLI
+
+Copilot hooks 是 **per-repo** 的（寫進 `.github/hooks/hooks.json`），所以每個專案各自安裝：
+
+```bash
+cd /path/to/your/repo
+DynamicIsland --install-copilot-hooks    # 預設使用 cwd
+# 或明確指定路徑
+DynamicIsland --install-copilot-hooks /path/to/repo
 ```
+
+會在 `{repoPath}/.github/hooks/hooks.json` 寫入 Copilot 的 hook 設定（camelCase 事件、`version: 1`、`bash`/`timeoutSec` 欄位），並把腳本部署到全域的 `~/.copilot/hooks/dynamic-island-hook.sh`。
+
+移除：
+
+```bash
+DynamicIsland --uninstall-copilot-hooks /path/to/repo
+```
+
+> ⚠️ `.github/hooks/hooks.json` 預設會被 git 追蹤。如果不想 commit 給隊友，加進 `.gitignore`。
 
 ### OpenAI Codex
 
@@ -244,7 +222,8 @@ pkill DynamicIsland
 
 ```
 Sources/DynamicIsland/
-├── App.swift                # NSApplication entry, AppDelegate
+├── App.swift                # NSApplication entry, CLI parsing, NSAlert prompt
+├── HookInstaller.swift      # Auto-install hooks for Claude Code & Copilot
 ├── IslandPanel.swift        # NSPanel, auto-detect notch dimensions
 ├── IslandState.swift        # State manager, immediate event display
 ├── IslandView.swift         # SwiftUI views (ears, thinking pulse, expanded)

--- a/Sources/DynamicIsland/App.swift
+++ b/Sources/DynamicIsland/App.swift
@@ -4,11 +4,64 @@ import SwiftUI
 @main
 struct DynamicIslandApp {
     static func main() {
+        let args = CommandLine.arguments
+        if args.contains("--install-hooks")           { runInstallCLI(target: .claudeCode);   exit(0) }
+        if args.contains("--install-copilot-hooks")   { runInstallCLI(target: .copilot);      exit(0) }
+        if args.contains("--uninstall-hooks")         { runUninstallCLI(target: .claudeCode); exit(0) }
+        if args.contains("--uninstall-copilot-hooks") { runUninstallCLI(target: .copilot);    exit(0) }
+        if args.contains("--help") || args.contains("-h") { printUsage(); exit(0) }
+
         let app = NSApplication.shared
         let delegate = AppDelegate()
         app.delegate = delegate
         app.setActivationPolicy(.accessory) // Hide from dock
         app.run()
+    }
+
+    private static func runInstallCLI(target: HookInstaller.Target) {
+        switch HookInstaller.syncIfOutdated(target: target) {
+        case .installed:
+            print("Installed \(target.displayName) hooks:")
+            print("  script:   \(target.deployedHookURL.path)")
+            print("  settings: \(target.settingsURL.path)")
+        case .alreadyCurrent:
+            print("\(target.displayName) hooks already up to date.")
+        case .skipped(let msg):
+            FileHandle.standardError.write(Data("Skipped: \(msg)\n".utf8))
+            exit(1)
+        case .failed(let reason):
+            FileHandle.standardError.write(Data("Failed: \(reason)\n".utf8))
+            exit(1)
+        default:
+            break
+        }
+    }
+
+    private static func runUninstallCLI(target: HookInstaller.Target) {
+        switch HookInstaller.uninstall(target: target) {
+        case .removed:
+            print("Removed \(target.displayName) hooks from \(target.settingsURL.path)")
+        case .notInstalled:
+            print("No \(target.displayName) hooks to remove.")
+        case .failed(let reason):
+            FileHandle.standardError.write(Data("Failed: \(reason)\n".utf8))
+            exit(1)
+        default:
+            break
+        }
+    }
+
+    private static func printUsage() {
+        print("""
+        Usage: DynamicIsland [options]
+
+          (no options)              Run the app normally.
+          --install-hooks           Install Claude Code hooks and exit.
+          --uninstall-hooks         Remove Claude Code hooks and exit.
+          --install-copilot-hooks   Install GitHub Copilot hooks and exit.
+          --uninstall-copilot-hooks Remove GitHub Copilot hooks and exit.
+          --help, -h                Show this help.
+        """)
     }
 }
 
@@ -16,6 +69,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var panel: IslandPanel!
     var stateManager = IslandStateManager()
     var server: LocalServer!
+
+    private static let hookChoiceKey = "hookInstallChoice"
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         panel = IslandPanel(stateManager: stateManager)
@@ -27,7 +82,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         NotificationMonitor.shared.start(stateManager: stateManager)
 
-        // Show welcome message
+        // First-run prompt (or silent sync for returning users) — Claude Code only.
+        // Copilot setup is CLI-only via --install-copilot-hooks.
+        maybePromptForHookInstall()
+
         stateManager.pushEvent(IslandEvent(
             icon: "🏝️",
             title: "Dynamic Island",
@@ -35,5 +93,69 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             style: .info,
             duration: 3.0
         ))
+    }
+
+    private func maybePromptForHookInstall() {
+        switch UserDefaults.standard.string(forKey: Self.hookChoiceKey) {
+        case "installed":
+            _ = HookInstaller.syncIfOutdated(target: .claudeCode)
+        case "declined":
+            break
+        default:
+            showInstallPrompt()
+        }
+    }
+
+    private func showInstallPrompt() {
+        let alert = NSAlert()
+        alert.messageText = "Configure Claude Code hooks?"
+        alert.informativeText = """
+            Dynamic Island needs Claude Code hooks to receive tool events.
+
+            Installing will:
+              • Copy island-hook.sh to ~/.claude/hooks/
+              • Register hook events in ~/.claude/settings.json
+
+            Other tools' hooks will not be touched.
+
+            You can also run this later from a terminal:
+              DynamicIsland --install-hooks            (Claude Code)
+              DynamicIsland --install-copilot-hooks    (GitHub Copilot)
+            """
+        alert.addButton(withTitle: "Install")
+        alert.addButton(withTitle: "Skip")
+        alert.addButton(withTitle: "Never")
+
+        switch alert.runModal() {
+        case .alertFirstButtonReturn:   // Install
+            let result = HookInstaller.install(target: .claudeCode)
+            UserDefaults.standard.set("installed", forKey: Self.hookChoiceKey)
+            reportInstallResult(result)
+        case .alertThirdButtonReturn:   // Never
+            UserDefaults.standard.set("declined", forKey: Self.hookChoiceKey)
+        default:                        // Skip — ask again next launch
+            break
+        }
+    }
+
+    private func reportInstallResult(_ result: HookInstaller.Result) {
+        switch result {
+        case .installed:
+            stateManager.pushEvent(IslandEvent(
+                title: "Hooks installed",
+                subtitle: "~/.claude/hooks/dynamic-island-hook.sh",
+                style: .success,
+                duration: 4.0
+            ))
+        case .skipped(let msg), .failed(let msg):
+            stateManager.pushEvent(IslandEvent(
+                title: "Hook install failed",
+                subtitle: msg,
+                style: .error,
+                duration: 6.0
+            ))
+        default:
+            break
+        }
     }
 }

--- a/Sources/DynamicIsland/App.swift
+++ b/Sources/DynamicIsland/App.swift
@@ -5,10 +5,14 @@ import SwiftUI
 struct DynamicIslandApp {
     static func main() {
         let args = CommandLine.arguments
-        if args.contains("--install-hooks")           { runInstallCLI(target: .claudeCode);   exit(0) }
-        if args.contains("--install-copilot-hooks")   { runInstallCLI(target: .copilot);      exit(0) }
-        if args.contains("--uninstall-hooks")         { runUninstallCLI(target: .claudeCode); exit(0) }
-        if args.contains("--uninstall-copilot-hooks") { runUninstallCLI(target: .copilot);    exit(0) }
+        if args.contains("--install-hooks")   { runInstallCLI(target: .claudeCode);   exit(0) }
+        if args.contains("--uninstall-hooks") { runUninstallCLI(target: .claudeCode); exit(0) }
+        if let repo = copilotRepoPath(in: args, after: "--install-copilot-hooks") {
+            runInstallCLI(target: .copilot(repoPath: repo)); exit(0)
+        }
+        if let repo = copilotRepoPath(in: args, after: "--uninstall-copilot-hooks") {
+            runUninstallCLI(target: .copilot(repoPath: repo)); exit(0)
+        }
         if args.contains("--help") || args.contains("-h") { printUsage(); exit(0) }
 
         let app = NSApplication.shared
@@ -16,6 +20,26 @@ struct DynamicIslandApp {
         app.delegate = delegate
         app.setActivationPolicy(.accessory) // Hide from dock
         app.run()
+    }
+
+    /// Returns the repo path for the Copilot CLI flag, or nil if the flag isn't present.
+    /// Accepts an optional path after the flag; defaults to CWD. Rejects missing/invalid dirs.
+    private static func copilotRepoPath(in args: [String], after flag: String) -> URL? {
+        guard let idx = args.firstIndex(of: flag) else { return nil }
+        let rawPath: String
+        if idx + 1 < args.count, !args[idx + 1].hasPrefix("--") {
+            rawPath = args[idx + 1]
+        } else {
+            rawPath = FileManager.default.currentDirectoryPath
+        }
+        let url = URL(fileURLWithPath: rawPath).standardized
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir),
+              isDir.boolValue else {
+            FileHandle.standardError.write(Data("Not a directory: \(url.path)\n".utf8))
+            exit(1)
+        }
+        return url
     }
 
     private static func runInstallCLI(target: HookInstaller.Target) {
@@ -55,12 +79,13 @@ struct DynamicIslandApp {
         print("""
         Usage: DynamicIsland [options]
 
-          (no options)              Run the app normally.
-          --install-hooks           Install Claude Code hooks and exit.
-          --uninstall-hooks         Remove Claude Code hooks and exit.
-          --install-copilot-hooks   Install GitHub Copilot hooks and exit.
-          --uninstall-copilot-hooks Remove GitHub Copilot hooks and exit.
-          --help, -h                Show this help.
+          (no options)                         Run the app normally.
+          --install-hooks                      Install Claude Code hooks (~/.claude/settings.json).
+          --uninstall-hooks                    Remove Claude Code hooks.
+          --install-copilot-hooks [repoPath]   Install Copilot hooks to {repoPath}/.github/hooks/hooks.json
+                                               (defaults to current directory).
+          --uninstall-copilot-hooks [repoPath] Remove Copilot hooks from that repo.
+          --help, -h                           Show this help.
         """)
     }
 }

--- a/Sources/DynamicIsland/HookInstaller.swift
+++ b/Sources/DynamicIsland/HookInstaller.swift
@@ -1,0 +1,295 @@
+import Foundation
+
+/// Deploys island-hook.sh and registers hook events for either Claude Code
+/// (~/.claude/settings.json) or GitHub Copilot (~/.copilot/hooks/hooks.json).
+///
+/// The two formats differ:
+///   Claude Code: { "matcher": "pattern", "hooks": [{ type, command, timeout }] }
+///   Copilot:     { type, command, timeout }   (flat, no matcher)
+enum HookInstaller {
+
+    enum Result {
+        case installed         // hooks written or updated
+        case alreadyCurrent    // settings already match desired state
+        case removed           // uninstall succeeded
+        case notInstalled      // nothing to remove
+        case skipped(String)   // source hook script not found (dev build)
+        case failed(String)
+    }
+
+    enum Target {
+        case claudeCode
+        case copilot
+
+        var displayName: String {
+            switch self {
+            case .claudeCode: return "Claude Code"
+            case .copilot:    return "Copilot"
+            }
+        }
+
+        var deployedHookURL: URL {
+            let home = FileManager.default.homeDirectoryForCurrentUser
+            switch self {
+            case .claudeCode: return home.appendingPathComponent(".claude/hooks/dynamic-island-hook.sh")
+            case .copilot:    return home.appendingPathComponent(".copilot/hooks/dynamic-island-hook.sh")
+            }
+        }
+
+        var settingsURL: URL {
+            let home = FileManager.default.homeDirectoryForCurrentUser
+            switch self {
+            case .claudeCode: return home.appendingPathComponent(".claude/settings.json")
+            case .copilot:    return home.appendingPathComponent(".copilot/hooks/hooks.json")
+            }
+        }
+
+        var usesMatcher: Bool { self == .claudeCode }
+
+        fileprivate var events: [(name: String, matcher: String, timeout: Int)] {
+            switch self {
+            case .claudeCode:
+                return [
+                    ("PreToolUse",         "",                                         5),
+                    ("PostToolUse",        "Bash|Edit|Write",                          5),
+                    ("PostToolUseFailure", "",                                         5),
+                    ("PermissionRequest",  "Bash|Edit|Write|MultiEdit|NotebookEdit",  30),
+                    ("PermissionDenied",   "",                                         5),
+                    ("Notification",       "",                                         5),
+                    ("Stop",               "",                                         5),
+                    ("StopFailure",        "",                                         5),
+                    ("SubagentStart",      "",                                         5),
+                    ("SubagentStop",       "",                                         5),
+                    ("UserPromptSubmit",   "",                                         5),
+                    ("SessionStart",       "",                                         5),
+                    ("SessionEnd",         "",                                         5),
+                    ("PreCompact",         "",                                         5),
+                    ("PostCompact",        "",                                         5),
+                ]
+            case .copilot:
+                return [
+                    ("PreToolUse",       "", 5),
+                    ("PostToolUse",      "", 5),
+                    ("UserPromptSubmit", "", 5),
+                    ("Stop",             "", 5),
+                    ("SessionStart",     "", 5),
+                    ("SubagentStart",    "", 5),
+                    ("SubagentStop",     "", 5),
+                ]
+            }
+        }
+    }
+
+    // MARK: - Public API
+
+    static func install(target: Target) -> Result {
+        guard let source = locateHookScript() else {
+            return .skipped("island-hook.sh not found in app bundle")
+        }
+        do {
+            try deployHookScript(from: source, to: target.deployedHookURL)
+            try writeSettings(target: target, shouldHaveHooks: true)
+            return .installed
+        } catch {
+            return .failed(error.localizedDescription)
+        }
+    }
+
+    static func syncIfOutdated(target: Target) -> Result {
+        currentlyInSync(target: target) ? .alreadyCurrent : install(target: target)
+    }
+
+    static func uninstall(target: Target) -> Result {
+        let hadSomething = anyOurEntryExists(target: target)
+            || FileManager.default.fileExists(atPath: target.deployedHookURL.path)
+        do {
+            try writeSettings(target: target, shouldHaveHooks: false)
+            try? FileManager.default.removeItem(at: target.deployedHookURL)
+            return hadSomething ? .removed : .notInstalled
+        } catch {
+            return .failed(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Source resolution
+
+    private static func locateHookScript() -> URL? {
+        if let url = Bundle.main.url(forResource: "island-hook", withExtension: "sh"),
+           FileManager.default.fileExists(atPath: url.path) {
+            return url
+        }
+        let exe = URL(fileURLWithPath: ProcessInfo.processInfo.arguments[0])
+        let candidates = [
+            exe.deletingLastPathComponent().appendingPathComponent("island-hook.sh"),
+            exe.deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("hooks/island-hook.sh"),
+        ]
+        return candidates.first { FileManager.default.fileExists(atPath: $0.path) }
+    }
+
+    private static func deployHookScript(from source: URL, to dest: URL) throws {
+        let dir = dest.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        if FileManager.default.fileExists(atPath: dest.path) {
+            try FileManager.default.removeItem(at: dest)
+        }
+        try FileManager.default.copyItem(at: source, to: dest)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: dest.path)
+    }
+
+    // MARK: - Settings manipulation
+
+    private static func currentlyInSync(target: Target) -> Bool {
+        guard FileManager.default.fileExists(atPath: target.deployedHookURL.path) else { return false }
+        guard let data = try? Data(contentsOf: target.settingsURL),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let hooks = root["hooks"] as? [String: Any] else {
+            return false
+        }
+        let path = target.deployedHookURL.path
+
+        for (event, matcher, timeout) in target.events {
+            guard let entries = hooks[event] as? [[String: Any]] else { return false }
+            let found = entries.contains { entry in
+                entryMatches(entry, target: target, matcher: matcher, command: path, timeout: timeout)
+            }
+            if !found { return false }
+        }
+
+        // Reject stale DI entries still pointing at other paths.
+        for (_, value) in hooks {
+            for entry in (value as? [[String: Any]] ?? []) {
+                for cmd in commandsIn(entry: entry, target: target) {
+                    if isOurs(commandPath: cmd), cmd != path { return false }
+                }
+            }
+        }
+        return true
+    }
+
+    private static func anyOurEntryExists(target: Target) -> Bool {
+        guard let data = try? Data(contentsOf: target.settingsURL),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let hooks = root["hooks"] as? [String: Any] else { return false }
+        for (_, value) in hooks {
+            for entry in (value as? [[String: Any]] ?? []) {
+                if commandsIn(entry: entry, target: target).contains(where: isOurs(commandPath:)) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    /// Extracts the hook command path(s) from an entry, accounting for the
+    /// target's schema (nested "hooks" array for Claude, flat for Copilot).
+    private static func commandsIn(entry: [String: Any], target: Target) -> [String] {
+        if target.usesMatcher {
+            return (entry["hooks"] as? [[String: Any]] ?? [])
+                .compactMap { $0["command"] as? String }
+        } else {
+            return [entry["command"] as? String].compactMap { $0 }
+        }
+    }
+
+    private static func entryMatches(
+        _ entry: [String: Any], target: Target,
+        matcher: String, command: String, timeout: Int
+    ) -> Bool {
+        if target.usesMatcher {
+            guard entry["matcher"] as? String == matcher,
+                  let inner = entry["hooks"] as? [[String: Any]] else { return false }
+            return inner.contains { h in
+                (h["command"] as? String) == command && (h["timeout"] as? Int) == timeout
+            }
+        } else {
+            return (entry["command"] as? String) == command
+                && (entry["timeout"] as? Int) == timeout
+        }
+    }
+
+    private static func isOurs(commandPath: String) -> Bool {
+        let markers = ["dynamic-island-hook", "island-hook.sh", "claude-hook.sh", "DynamicIsland"]
+        return markers.contains { commandPath.contains($0) }
+    }
+
+    struct SettingsParseError: LocalizedError {
+        let path: String
+        var errorDescription: String? {
+            "\(path) exists but is not valid JSON — refusing to overwrite. Fix or remove the file and retry."
+        }
+    }
+
+    /// Rewrite settings file, preserving entries from other tools. Refuses to
+    /// proceed if the existing file is unreadable JSON.
+    private static func writeSettings(target: Target, shouldHaveHooks: Bool) throws {
+        let url = target.settingsURL
+        var root: [String: Any] = [:]
+        if let data = try? Data(contentsOf: url), !data.isEmpty {
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                throw SettingsParseError(path: url.path)
+            }
+            root = json
+        }
+        var hooks = root["hooks"] as? [String: Any] ?? [:]
+
+        // Strip any existing Dynamic Island entries.
+        for key in Array(hooks.keys) {
+            var entries = hooks[key] as? [[String: Any]] ?? []
+            entries.removeAll { entry in
+                commandsIn(entry: entry, target: target).contains(where: isOurs(commandPath:))
+            }
+            if entries.isEmpty {
+                hooks.removeValue(forKey: key)
+            } else {
+                hooks[key] = entries
+            }
+        }
+
+        if shouldHaveHooks {
+            let path = target.deployedHookURL.path
+            for (event, matcher, timeout) in target.events {
+                var entries = hooks[event] as? [[String: Any]] ?? []
+                entries.append(newEntry(target: target, matcher: matcher, command: path, timeout: timeout))
+                hooks[event] = entries
+            }
+        }
+
+        if hooks.isEmpty {
+            root.removeValue(forKey: "hooks")
+        } else {
+            root["hooks"] = hooks
+        }
+
+        let parent = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+
+        let data = try JSONSerialization.data(
+            withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: url)
+    }
+
+    private static func newEntry(
+        target: Target, matcher: String, command: String, timeout: Int
+    ) -> [String: Any] {
+        if target.usesMatcher {
+            return [
+                "matcher": matcher,
+                "hooks": [[
+                    "type": "command",
+                    "command": command,
+                    "timeout": timeout,
+                ]],
+            ]
+        } else {
+            return [
+                "type": "command",
+                "command": command,
+                "timeout": timeout,
+            ]
+        }
+    }
+}

--- a/Sources/DynamicIsland/HookInstaller.swift
+++ b/Sources/DynamicIsland/HookInstaller.swift
@@ -19,7 +19,8 @@ enum HookInstaller {
 
     enum Target {
         case claudeCode
-        case copilot
+        /// Copilot hooks are per-repo, written to `{repoPath}/.github/hooks/hooks.json`.
+        case copilot(repoPath: URL)
 
         var displayName: String {
             switch self {
@@ -31,20 +32,30 @@ enum HookInstaller {
         var deployedHookURL: URL {
             let home = FileManager.default.homeDirectoryForCurrentUser
             switch self {
-            case .claudeCode: return home.appendingPathComponent(".claude/hooks/dynamic-island-hook.sh")
-            case .copilot:    return home.appendingPathComponent(".copilot/hooks/dynamic-island-hook.sh")
+            case .claudeCode:
+                return home.appendingPathComponent(".claude/hooks/dynamic-island-hook.sh")
+            case .copilot:
+                // Script lives globally; each repo's config just references it.
+                return home.appendingPathComponent(".copilot/hooks/dynamic-island-hook.sh")
             }
         }
 
         var settingsURL: URL {
-            let home = FileManager.default.homeDirectoryForCurrentUser
             switch self {
-            case .claudeCode: return home.appendingPathComponent(".claude/settings.json")
-            case .copilot:    return home.appendingPathComponent(".copilot/hooks/hooks.json")
+            case .claudeCode:
+                return FileManager.default.homeDirectoryForCurrentUser
+                    .appendingPathComponent(".claude/settings.json")
+            case .copilot(let repoPath):
+                return repoPath.appendingPathComponent(".github/hooks/hooks.json")
             }
         }
 
-        var usesMatcher: Bool { self == .claudeCode }
+        var usesMatcher: Bool {
+            switch self {
+            case .claudeCode: return true
+            case .copilot:    return false
+            }
+        }
 
         fileprivate var events: [(name: String, matcher: String, timeout: Int)] {
             switch self {
@@ -67,14 +78,14 @@ enum HookInstaller {
                     ("PostCompact",        "",                                         5),
                 ]
             case .copilot:
+                // camelCase event names, per docs.github.com/en/copilot/.../cloud-agent/use-hooks
                 return [
-                    ("PreToolUse",       "", 5),
-                    ("PostToolUse",      "", 5),
-                    ("UserPromptSubmit", "", 5),
-                    ("Stop",             "", 5),
-                    ("SessionStart",     "", 5),
-                    ("SubagentStart",    "", 5),
-                    ("SubagentStop",     "", 5),
+                    ("preToolUse",          "", 5),
+                    ("postToolUse",         "", 5),
+                    ("userPromptSubmitted", "", 5),
+                    ("sessionStart",        "", 5),
+                    ("sessionEnd",          "", 5),
+                    ("errorOccurred",       "", 5),
                 ]
             }
         }
@@ -185,13 +196,15 @@ enum HookInstaller {
     }
 
     /// Extracts the hook command path(s) from an entry, accounting for the
-    /// target's schema (nested "hooks" array for Claude, flat for Copilot).
+    /// target's schema (Claude Code: nested "hooks" array with "command";
+    /// Copilot: flat entry with "bash").
     private static func commandsIn(entry: [String: Any], target: Target) -> [String] {
-        if target.usesMatcher {
+        switch target {
+        case .claudeCode:
             return (entry["hooks"] as? [[String: Any]] ?? [])
                 .compactMap { $0["command"] as? String }
-        } else {
-            return [entry["command"] as? String].compactMap { $0 }
+        case .copilot:
+            return [entry["bash"] as? String].compactMap { $0 }
         }
     }
 
@@ -199,15 +212,16 @@ enum HookInstaller {
         _ entry: [String: Any], target: Target,
         matcher: String, command: String, timeout: Int
     ) -> Bool {
-        if target.usesMatcher {
+        switch target {
+        case .claudeCode:
             guard entry["matcher"] as? String == matcher,
                   let inner = entry["hooks"] as? [[String: Any]] else { return false }
             return inner.contains { h in
                 (h["command"] as? String) == command && (h["timeout"] as? Int) == timeout
             }
-        } else {
-            return (entry["command"] as? String) == command
-                && (entry["timeout"] as? Int) == timeout
+        case .copilot:
+            return (entry["bash"] as? String) == command
+                && (entry["timeoutSec"] as? Int) == timeout
         }
     }
 
@@ -264,6 +278,11 @@ enum HookInstaller {
             root["hooks"] = hooks
         }
 
+        // Copilot requires a top-level schema version field.
+        if case .copilot = target, shouldHaveHooks {
+            root["version"] = 1
+        }
+
         let parent = url.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
 
@@ -275,7 +294,8 @@ enum HookInstaller {
     private static func newEntry(
         target: Target, matcher: String, command: String, timeout: Int
     ) -> [String: Any] {
-        if target.usesMatcher {
+        switch target {
+        case .claudeCode:
             return [
                 "matcher": matcher,
                 "hooks": [[
@@ -284,11 +304,11 @@ enum HookInstaller {
                     "timeout": timeout,
                 ]],
             ]
-        } else {
+        case .copilot:
             return [
                 "type": "command",
-                "command": command,
-                "timeout": timeout,
+                "bash": command,
+                "timeoutSec": timeout,
             ]
         }
     }


### PR DESCRIPTION
## Summary
- New `HookInstaller` deploys `island-hook.sh` and registers hook events automatically. First launch shows an NSAlert (Install / Skip / Never), and the choice persists in UserDefaults — subsequent launches silently sync if drift is detected (idempotent).
- CLI flags for scripted install / removal:
  - `--install-hooks` / `--uninstall-hooks` — Claude Code (writes `~/.claude/settings.json`)
  - `--install-copilot-hooks [path]` / `--uninstall-copilot-hooks [path]` — Copilot (writes `{path}/.github/hooks/hooks.json`, defaults to cwd)
- Hook script is deployed to a stable location (`~/.claude/hooks/dynamic-island-hook.sh`) so moving the .app no longer breaks the registration.
- Bonus: also caught up on six missing Claude Code hook events (`PostToolUseFailure`, `PermissionDenied`, `StopFailure`, `SessionEnd`, `PreCompact`, `PostCompact`) and added a FIFO context cache so `PermissionRequest` dialogs show the actual diff for Edit / content for Write / fallback command for Bash.

Copilot target is per-repo, with the correct schema per the official docs (top-level `version: 1`, camelCase events, `bash` / `timeoutSec` fields, no matcher).

Safety: the installer detects existing Dynamic Island entries by command-path markers and only touches those — entries from other tools (e.g. gemini-bridge) are preserved. Refuses to overwrite settings.json if the existing JSON is unparseable.

## Test plan
- [ ] First launch on a clean machine shows the NSAlert; clicking **Install** sets up Claude Code hooks
- [ ] `DynamicIsland --install-hooks` writes `~/.claude/settings.json` and exits with status
- [ ] Running `--install-hooks` twice prints "Already up to date" the second time
- [ ] `DynamicIsland --uninstall-hooks` removes our entries but preserves other tools' hooks
- [ ] `DynamicIsland --install-copilot-hooks /path/to/repo` produces a `.github/hooks/hooks.json` matching the official schema
- [ ] Trigger an Edit permission request — the dialog now shows a colored diff
- [ ] Run a Bash command that fails — `Tool failed` notification appears (was previously silent unless stdout matched grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)