### PR TITLE
Color island by AI source (Claude / Copilot / Codex)

### DIFF
--- a/Sources/DynamicIsland/IslandState.swift
+++ b/Sources/DynamicIsland/IslandState.swift
@@ -14,13 +14,19 @@ struct IslandEvent: Identifiable {
     let progress: Double?
     let persistent: Bool  // if true, won't auto-dismiss
     let project: String?  // small project name label
+    let source: String?   // "claude" / "copilot" / "codex" — drives color
 
-    /// Deterministic color derived from project name
+    /// Color signaling event source. Falls back to a deterministic
+    /// project-name hash when the source isn't known, so legacy callers
+    /// (e.g. plain HTTP POST without source) still get visual variety.
     var projectColor: Color? {
+        if let source, let color = Self.sourceColor(source) {
+            return color
+        }
         guard let project, !project.isEmpty else { return nil }
         let hash = project.utf8.reduce(0) { ($0 &+ UInt32($1)) &* 31 }
         let palette: [Color] = [
-            Color(red: 0.85, green: 0.65, blue: 0.45), // warm orange (default claude)
+            Color(red: 0.85, green: 0.65, blue: 0.45), // warm orange
             Color(red: 0.55, green: 0.75, blue: 1.0),  // sky blue
             Color(red: 0.65, green: 0.9,  blue: 0.65), // mint green
             Color(red: 0.9,  green: 0.6,  blue: 0.9),  // lavender
@@ -30,6 +36,15 @@ struct IslandEvent: Identifiable {
             Color(red: 0.7,  green: 0.7,  blue: 1.0),  // periwinkle
         ]
         return palette[Int(hash) % palette.count]
+    }
+
+    private static func sourceColor(_ source: String) -> Color? {
+        switch source.lowercased() {
+        case "claude":  return Color(red: 0.85, green: 0.65, blue: 0.45) // warm orange
+        case "copilot": return Color(red: 0.65, green: 0.50, blue: 0.95) // GitHub violet
+        case "codex":   return Color(red: 0.30, green: 0.80, blue: 0.60) // OpenAI green
+        default: return nil
+        }
     }
 
     init(
@@ -42,7 +57,8 @@ struct IslandEvent: Identifiable {
         detail: String? = nil,
         progress: Double? = nil,
         persistent: Bool = false,
-        project: String? = nil
+        project: String? = nil,
+        source: String? = nil
     ) {
         self.id = id
         self.icon = icon
@@ -54,6 +70,7 @@ struct IslandEvent: Identifiable {
         self.progress = progress
         self.persistent = persistent
         self.project = project
+        self.source = source
     }
 }
 

--- a/Sources/DynamicIsland/IslandView.swift
+++ b/Sources/DynamicIsland/IslandView.swift
@@ -201,10 +201,21 @@ struct LeftEarView: View {
             LeftEarShape(outerRadius: 16, notchRadius: 10)
                 .fill(.black)
 
-            // Pulsing border for action/reminder events
+            // Source-color stripe down the leading (outer) edge.
+            // Clipped to the ear shape so it follows the rounded outer corner.
+            if let color = event?.projectColor, isVisible {
+                Rectangle()
+                    .fill(color)
+                    .frame(width: 4)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .mask(LeftEarShape(outerRadius: 16, notchRadius: 10))
+            }
+
+            // Pulsing border for action/reminder events — uses source color when known
             if isPulsing {
+                let pulseColor = event?.projectColor ?? event!.style.color
                 LeftEarShape(outerRadius: 16, notchRadius: 10)
-                    .stroke(event!.style.color.opacity(actionPulse ? 0.8 : 0.2), lineWidth: 1.5)
+                    .stroke(pulseColor.opacity(actionPulse ? 0.8 : 0.2), lineWidth: 1.5)
             }
 
             if isVisible, let event {
@@ -231,7 +242,12 @@ struct LeftEarView: View {
                 .transition(.opacity.combined(with: .scale(scale: 0.9)))
             }
         }
-        .shadow(color: isPulsing ? (event?.style.color ?? .clear).opacity(actionPulse ? 0.6 : 0.1) : .clear, radius: 8)
+        .shadow(
+            color: isPulsing
+                ? (event?.projectColor ?? event?.style.color ?? .clear).opacity(actionPulse ? 0.6 : 0.1)
+                : .clear,
+            radius: 8
+        )
         .onTapGesture {
             if isPulsing { stateManager.dismiss() } else { stateManager.expand() }
         }
@@ -266,9 +282,19 @@ struct RightEarView: View {
             RightEarShape(outerRadius: 16, notchRadius: 10)
                 .fill(.black)
 
+            // Source-color stripe down the trailing (outer) edge
+            if let color = event?.projectColor, isVisible {
+                Rectangle()
+                    .fill(color)
+                    .frame(width: 4)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+                    .mask(RightEarShape(outerRadius: 16, notchRadius: 10))
+            }
+
             if isPulsing {
+                let pulseColor = event?.projectColor ?? event!.style.color
                 RightEarShape(outerRadius: 16, notchRadius: 10)
-                    .stroke(event!.style.color.opacity(actionPulse ? 0.8 : 0.2), lineWidth: 1.5)
+                    .stroke(pulseColor.opacity(actionPulse ? 0.8 : 0.2), lineWidth: 1.5)
             }
 
             if isVisible, let event {
@@ -294,7 +320,12 @@ struct RightEarView: View {
                 .transition(.opacity.combined(with: .scale(scale: 0.9)))
             }
         }
-        .shadow(color: isPulsing ? (event?.style.color ?? .clear).opacity(actionPulse ? 0.6 : 0.1) : .clear, radius: 8)
+        .shadow(
+            color: isPulsing
+                ? (event?.projectColor ?? event?.style.color ?? .clear).opacity(actionPulse ? 0.6 : 0.1)
+                : .clear,
+            radius: 8
+        )
         .onTapGesture {
             if isPulsing { stateManager.dismiss() } else { stateManager.expand() }
         }

--- a/Sources/DynamicIsland/LocalServer.swift
+++ b/Sources/DynamicIsland/LocalServer.swift
@@ -257,6 +257,7 @@ class LocalServer {
         let styleName = json["style"] as? String ?? "claude"
         let progress = json["progress"] as? Double
         let project = json["project"] as? String
+        let source = json["source"] as? String
 
         // Progress semantics: in-progress events stay until complete,
         // completion (progress >= 1.0) gets a short celebratory duration
@@ -286,7 +287,8 @@ class LocalServer {
             detail: detail,
             progress: progress,
             persistent: persistent,
-            project: project
+            project: project,
+            source: source
         )
 
         // Route into the session tree: main session when no agent_id, else

--- a/hooks/island-hook.sh
+++ b/hooks/island-hook.sh
@@ -32,6 +32,9 @@ send() {
     if [ -n "$AGENT_ID" ]; then
         payload=$(echo "$payload" | jq -c --arg id "$AGENT_ID" --arg t "$AGENT_TYPE" '. + {agent_id: $id, agent_type: $t}')
     fi
+    if [ -n "$SOURCE" ]; then
+        payload=$(echo "$payload" | jq -c --arg s "$SOURCE" '. + {source: $s}')
+    fi
     curl -s -X POST "$URL" \
         -H "Content-Type: application/json" \
         -d "$payload" > /dev/null 2>&1 &
@@ -84,15 +87,25 @@ CP_SOURCE=$(echo "$INPUT" | jq -r '.source // empty')
 CP_REASON=$(echo "$INPUT" | jq -r '.reason // empty')
 CP_ERROR=$(echo "$INPUT" | jq -r '.error.message? // empty')
 
-# ─── Normalize to a common event + tool ───
+# ─── Normalize to a common event + tool, and detect source ───
+# SOURCE drives the project color in the island UI:
+#   claude  → warm orange    copilot → GitHub violet    codex → OpenAI green
+# Override via ISLAND_SOURCE env var (Codex hook script should set this).
+SOURCE="${ISLAND_SOURCE:-}"
+
 if [ -n "$CC_EVENT" ]; then
-    # Claude Code
     EVENT="$CC_EVENT"
     TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
+    # First-letter casing distinguishes Claude Code (PascalCase like
+    # "PreToolUse") from Copilot CLI (camelCase like "preToolUse").
+    [ -z "$SOURCE" ] && case "$CC_EVENT" in
+        [a-z]*) SOURCE="copilot" ;;
+        *)      SOURCE="claude"  ;;
+    esac
 else
-    # GitHub Copilot — detect event type from available fields
+    # Older Copilot detection — toolName at root, no hook_event_name.
+    [ -z "$SOURCE" ] && SOURCE="copilot"
     if [ -n "$CP_TOOL" ]; then
-        # Has toolName → pre or post tool use
         RESULT_TYPE=$(echo "$INPUT" | jq -r '.toolResult.resultType // empty')
         if [ -n "$RESULT_TYPE" ]; then
             EVENT="PostToolUse"
@@ -111,6 +124,19 @@ else
     else
         exit 0
     fi
+fi
+
+# Normalize Copilot's camelCase event names to the PascalCase forms the
+# rest of this script switches on.
+if [ "$SOURCE" = "copilot" ]; then
+    case "$EVENT" in
+        preToolUse)          EVENT="PreToolUse" ;;
+        postToolUse)         EVENT="PostToolUse" ;;
+        userPromptSubmitted) EVENT="UserPromptSubmit" ;;
+        sessionStart)        EVENT="SessionStart" ;;
+        sessionEnd)          EVENT="SessionEnd" ;;
+        errorOccurred)       EVENT="Error" ;;
+    esac
 fi
 
 # ─── Helper: extract file path from either format ───


### PR DESCRIPTION
## Summary
- Vertical color stripe down each ear's outer edge signals which AI sent the event:
  - **Claude Code** → warm orange
  - **Copilot** → GitHub violet
  - **Codex** → OpenAI green
- Action/reminder pulse stroke and shadow follow the same color — a permission request from Claude now glows orange instead of generic blue, so concurrent sessions are visually distinguishable even at a glance.
- The hook script auto-detects source by \`hook_event_name\` casing (PascalCase = Claude, camelCase = Copilot) with a fallback to the legacy \`toolName\`-at-root sniff. Codex hooks set \`ISLAND_SOURCE=codex\` to opt in.
- Backwards compatible: when no \`source\` field is sent (legacy HTTP API users), the existing project-name hash palette still drives the color.

## Test plan
- [ ] Send a Claude Code event → orange stripe appears on both ears
- [ ] Send a Copilot event (camelCase event name) → violet stripe
- [ ] Send a Codex event (with \`source: "codex"\` or \`ISLAND_SOURCE=codex\`) → green stripe
- [ ] Trigger a Claude PermissionRequest → pulse glow is orange (was blue)
- [ ] Send an event without source via plain HTTP POST → falls back to project-hash color

🤖 Generated with [Claude Code](https://claude.com/claude-code)