### PR TITLE
Fix hook script drift detection + source misclassification

### DIFF
--- a/Sources/DynamicIsland/HookInstaller.swift
+++ b/Sources/DynamicIsland/HookInstaller.swift
@@ -140,6 +140,16 @@ enum HookInstaller {
         return candidates.first { FileManager.default.fileExists(atPath: $0.path) }
     }
 
+    /// Detects content drift between the bundled source script and the deployed copy.
+    /// If we can't locate a source (dev-build edge case), assume in sync to avoid
+    /// triggering an unfixable redeploy loop.
+    private static func deployedScriptMatchesSource(target: Target) -> Bool {
+        guard let source = locateHookScript() else { return true }
+        guard let deployed = try? Data(contentsOf: target.deployedHookURL),
+              let bundled  = try? Data(contentsOf: source) else { return false }
+        return deployed == bundled
+    }
+
     private static func deployHookScript(from source: URL, to dest: URL) throws {
         let dir = dest.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -155,6 +165,7 @@ enum HookInstaller {
 
     private static func currentlyInSync(target: Target) -> Bool {
         guard FileManager.default.fileExists(atPath: target.deployedHookURL.path) else { return false }
+        guard deployedScriptMatchesSource(target: target) else { return false }
         guard let data = try? Data(contentsOf: target.settingsURL),
               let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let hooks = root["hooks"] as? [String: Any] else {

--- a/hooks/island-hook.sh
+++ b/hooks/island-hook.sh
@@ -98,9 +98,11 @@ if [ -n "$CC_EVENT" ]; then
     TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
     # First-letter casing distinguishes Claude Code (PascalCase like
     # "PreToolUse") from Copilot CLI (camelCase like "preToolUse").
+    # Use POSIX [[:upper:]] — `[A-Z]` would mis-match in en_US.UTF-8 where
+    # collation interleaves cases (P ∈ [a-z]).
     [ -z "$SOURCE" ] && case "$CC_EVENT" in
-        [a-z]*) SOURCE="copilot" ;;
-        *)      SOURCE="claude"  ;;
+        [[:upper:]]*) SOURCE="claude"  ;;
+        *)            SOURCE="copilot" ;;
     esac
 else
     # Older Copilot detection — toolName at root, no hook_event_name.


### PR DESCRIPTION
Two related fixes that together restore correct source coloring after a v1.4.1 install.

## 1. Detect script content drift on sync
Updating the .app shipped a new \`island-hook.sh\` in Resources, but \`syncIfOutdated()\` only inspected \`settings.json\` — so the stale copy at \`~/.claude/hooks/dynamic-island-hook.sh\` kept running, silently dropping new fields like \`source\`.

\`currentlyInSync\` now also byte-compares the deployed script against the bundled source. Drift triggers a redeploy on next launch or \`--install-hooks\` invocation. Falls back to "in sync" when no bundled source can be located (dev build edge case) to avoid an unrecoverable redeploy loop.

## 2. Fix source detection mis-classifying Claude as Copilot
\`bash\` \`case "$CC_EVENT" in [a-z]*)\` mis-matches uppercase letters in \`en_US.UTF-8\` because the locale's collation order interleaves cases — \`P\` falls inside \`[a-z]\`. So \`"PreToolUse"\` was being tagged as Copilot, the \`source\` field was set to \`copilot\`, and the island fell through to the project-name hash palette (which happened to land on violet for "swift-life").

Switched to \`[[:upper:]]\` POSIX class and inverted the test so the explicit branch is \`claude\`.

## Test plan
- [ ] Tamper with deployed script → \`--install-hooks\` reports "Installed" and redeploys
- [ ] Claude Code event (PascalCase \`hook_event_name\`) → \`source: "claude"\` in POST body, orange stripe
- [ ] Copilot event (camelCase \`hook_event_name\`) → \`source: "copilot"\`, violet stripe
- [ ] Idempotent: second \`--install-hooks\` reports "Already up to date"

🤖 Generated with [Claude Code](https://claude.com/claude-code)