### PR TITLE
Menu bar icon + fix click-blocking near the notch

### DIFF
--- a/Sources/DynamicIsland/App.swift
+++ b/Sources/DynamicIsland/App.swift
@@ -94,6 +94,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var panel: IslandPanel!
     var stateManager = IslandStateManager()
     var server: LocalServer!
+    var statusItem: NSStatusItem!
 
     private static let hookChoiceKey = "hookInstallChoice"
 
@@ -107,6 +108,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         NotificationMonitor.shared.start(stateManager: stateManager)
 
+        setupStatusBarItem()
+
         // First-run prompt (or silent sync for returning users) — Claude Code only.
         // Copilot setup is CLI-only via --install-copilot-hooks.
         maybePromptForHookInstall()
@@ -118,6 +121,66 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             style: .info,
             duration: 3.0
         ))
+    }
+
+    // MARK: - Menu bar status item
+
+    private func setupStatusBarItem() {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        statusItem.button?.image = makeIslandIcon()
+
+        let menu = NSMenu()
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+        let header = NSMenuItem(title: "Dynamic Island v\(version)", action: nil, keyEquivalent: "")
+        header.isEnabled = false
+        menu.addItem(header)
+        menu.addItem(.separator())
+        menu.addItem(NSMenuItem(
+            title: "Reinstall Claude Code Hooks",
+            action: #selector(reinstallHooks),
+            keyEquivalent: ""))
+        menu.addItem(.separator())
+        let quit = NSMenuItem(
+            title: "Quit Dynamic Island",
+            action: #selector(NSApplication.terminate(_:)),
+            keyEquivalent: "q")
+        menu.addItem(quit)
+        statusItem.menu = menu
+    }
+
+    /// A horizontal pill — the Dynamic Island silhouette in compact form.
+    /// Drawn inside a 22×22 canvas so the click target matches the menu bar's
+    /// standard hit area, with the pill itself centered for visual proportion.
+    /// Template-rendered so it adapts to light/dark menu bars.
+    private func makeIslandIcon() -> NSImage {
+        let canvas = NSSize(width: 22, height: 22)
+        let pillSize = NSSize(width: 18, height: 8)
+        let image = NSImage(size: canvas, flipped: false) { _ in
+            let pillRect = NSRect(
+                x: (canvas.width  - pillSize.width)  / 2,
+                y: (canvas.height - pillSize.height) / 2,
+                width: pillSize.width,
+                height: pillSize.height
+            )
+            let path = NSBezierPath(
+                roundedRect: pillRect,
+                xRadius: pillSize.height / 2,
+                yRadius: pillSize.height / 2
+            )
+            NSColor.labelColor.setFill()
+            path.fill()
+            return true
+        }
+        image.isTemplate = true
+        return image
+    }
+
+    @objc private func reinstallHooks() {
+        let result = HookInstaller.install(target: .claudeCode)
+        reportInstallResult(result)
+        if case .installed = result {
+            UserDefaults.standard.set("installed", forKey: Self.hookChoiceKey)
+        }
     }
 
     private func maybePromptForHookInstall() {

--- a/Sources/DynamicIsland/IslandPanel.swift
+++ b/Sources/DynamicIsland/IslandPanel.swift
@@ -1,8 +1,10 @@
 import AppKit
+import Combine
 import SwiftUI
 
 class IslandPanel: NSPanel {
     let stateManager: IslandStateManager
+    private var cancellables: Set<AnyCancellable> = []
 
     // Auto-detected from screen, with sensible fallbacks
     static var notchWidth: CGFloat = 185
@@ -54,7 +56,8 @@ class IslandPanel: NSPanel {
         self.isMovableByWindowBackground = false
         self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
         self.hidesOnDeactivate = false
-        self.ignoresMouseEvents = false
+        // Start click-through; toggled on when there's something to interact with.
+        self.ignoresMouseEvents = true
         self.acceptsMouseMovedEvents = true
 
         let hostView = NSHostingView(
@@ -63,6 +66,16 @@ class IslandPanel: NSPanel {
         )
         hostView.layer?.backgroundColor = .clear
         self.contentView = hostView
+
+        // Pass clicks through to whatever is behind the notch when no event is
+        // showing — without this, the panel's transparent gap blocks menu-bar
+        // items behind the camera notch.
+        Publishers.CombineLatest(stateManager.$mode, stateManager.$currentEvent)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] mode, event in
+                self?.ignoresMouseEvents = (mode == .hidden && event == nil)
+            }
+            .store(in: &cancellables)
     }
 
     func show() {


### PR DESCRIPTION
## Summary
- **Menu bar icon** — \`NSStatusItem\` with a template-rendered horizontal pill (the Dynamic Island silhouette in compact form). Click target uses the full 22×22 canvas so it hits like any other menu-bar item; the pill itself stays 18×8 visually for proportion.
- Menu items: version label, **Reinstall Claude Code Hooks** (handy for support / drift recovery), **Quit Dynamic Island** (no more \`pkill DynamicIsland\` from terminal).
- **Click-blocking fix** — the panel spans \`earWidth*2 + notchWidth\` (~465pt) and used to swallow every click in that strip even when no event was showing, making menu-bar items behind the camera notch unreachable. The panel now toggles \`ignoresMouseEvents\` from a Combine subscription on \`mode\` + \`currentEvent\` — true when idle, false when there's content to interact with.

## Test plan
- [ ] Menu bar icon visible, click opens menu with Quit
- [ ] Quit terminates the app cleanly
- [ ] Reinstall Hooks runs the installer; success / failure surfaces in the island
- [ ] When no event is showing, menu-bar items behind the notch (e.g. Spotlight, Wifi) become clickable again
- [ ] When an event is showing, clicking the ear still expands / dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)