### PR TITLE
Extract IslandHookCore library + add 58 unit tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,12 +9,22 @@ let package = Package(
             name: "DynamicIsland",
             path: "Sources/DynamicIsland"
         ),
+        // Pure-logic library extracted from island-hook. Foundation-only so
+        // it can be linked from the tiny hook CLI and covered by XCTest.
+        .target(
+            name: "IslandHookCore",
+            path: "Sources/IslandHookCore"
+        ),
         // Tiny CLI binary that replaces hooks/island-hook.sh.
-        // Foundation-only so the binary stays small and the user no longer
-        // needs jq installed.
         .executableTarget(
             name: "island-hook",
+            dependencies: ["IslandHookCore"],
             path: "Sources/island-hook"
+        ),
+        .testTarget(
+            name: "IslandHookCoreTests",
+            dependencies: ["IslandHookCore"],
+            path: "Tests/IslandHookCoreTests"
         ),
     ]
 )

--- a/Sources/IslandHookCore/Format.swift
+++ b/Sources/IslandHookCore/Format.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Truncate a string to `max` characters, appending an ellipsis if trimmed.
+public func truncate(_ s: String, _ max: Int) -> String {
+    s.count > max ? String(s.prefix(max)) + "…" : s
+}
+
+/// POSIX-style basename — last path component.
+public func basename(_ path: String) -> String {
+    (path as NSString).lastPathComponent
+}
+
+/// Trim a multi-line string to the first `maxLines` lines, each truncated
+/// to `maxChars`, each prefixed by `prefix`. Appends "  (+K more)" if lines
+/// were dropped. Empty string in → empty string out.
+public func diffLines(
+    _ text: String,
+    prefix: String,
+    maxLines: Int = 5,
+    maxChars: Int = 80
+) -> String {
+    if text.isEmpty { return "" }
+    let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+    var out: [String] = []
+    for line in lines.prefix(maxLines) {
+        let trimmed = line.count > maxChars ? String(line.prefix(maxChars)) + "…" : line
+        out.append(prefix + trimmed)
+    }
+    if lines.count > maxLines {
+        out.append("  (+\(lines.count - maxLines) more)")
+    }
+    return out.joined(separator: "\n")
+}
+
+/// Build a "- old / + new" preview from two multi-line strings. Either side
+/// can be empty — result is empty only if both are.
+public func buildEditDiff(old: String, new: String) -> String {
+    var parts: [String] = []
+    if !old.isEmpty { parts.append(diffLines(old, prefix: "- ")) }
+    if !new.isEmpty { parts.append(diffLines(new, prefix: "+ ")) }
+    return parts.joined(separator: "\n")
+}

--- a/Sources/IslandHookCore/HookPlan.swift
+++ b/Sources/IslandHookCore/HookPlan.swift
@@ -1,0 +1,164 @@
+import Foundation
+
+/// Result of parsing a hook payload: source, normalized event/tool names,
+/// project labels, and pre-extracted fields needed by payload builders.
+public struct HookPlan {
+    public let payload: [String: Any]
+    public let source: String          // "claude" | "copilot" | "codex"
+    public let event: String            // normalized PascalCase event name
+    public let tool: String             // normalized tool name
+    public let cwd: String
+    public let project: String
+    public let displayProject: String   // project OR "↳ agent_type" for subagents
+    public let agentId: String?
+    public let agentType: String?
+    public let toolInput: [String: Any]
+    public let copilotToolArgs: [String: Any]
+    public let cpError: String?         // Copilot .error.message for Error events
+
+    public init(
+        payload: [String: Any], source: String, event: String, tool: String,
+        cwd: String, project: String, displayProject: String,
+        agentId: String?, agentType: String?,
+        toolInput: [String: Any], copilotToolArgs: [String: Any],
+        cpError: String?
+    ) {
+        self.payload = payload
+        self.source = source
+        self.event = event
+        self.tool = tool
+        self.cwd = cwd
+        self.project = project
+        self.displayProject = displayProject
+        self.agentId = agentId
+        self.agentType = agentType
+        self.toolInput = toolInput
+        self.copilotToolArgs = copilotToolArgs
+        self.cpError = cpError
+    }
+}
+
+/// Parse a raw hook payload into a `HookPlan`, returning nil if the payload
+/// doesn't match any routable shape. Pure — no I/O.
+public func parseHookPlan(payload: [String: Any], env: [String: String] = [:]) -> HookPlan? {
+    // SOURCE drives the project color:
+    //   claude  → warm orange    copilot → GitHub violet    codex → OpenAI green
+    // Override via ISLAND_SOURCE env var (Codex hook script should set this).
+    var source = env["ISLAND_SOURCE"] ?? ""
+
+    let ccEvent = payload["hook_event_name"] as? String
+    let cpTool = payload["toolName"] as? String
+    let cpPrompt = payload["prompt"] as? String
+    let cpSource = payload["source"] as? String
+    let cpReason = payload["reason"] as? String
+    let cpError = (payload["error"] as? [String: Any])?["message"] as? String
+
+    var event = ""
+    var tool = ""
+
+    if let ccEvent = ccEvent {
+        event = ccEvent
+        tool = (payload["tool_name"] as? String) ?? ""
+        // First-letter casing distinguishes Claude (PascalCase) from Copilot (camelCase).
+        if source.isEmpty {
+            source = (ccEvent.first?.isUppercase ?? true) ? "claude" : "copilot"
+        }
+    } else {
+        if source.isEmpty { source = "copilot" }
+        if let cpTool = cpTool {
+            let resultType = (payload["toolResult"] as? [String: Any])?["resultType"] as? String
+            event = (resultType != nil) ? "PostToolUse" : "PreToolUse"
+            tool = cpTool
+        } else if cpError != nil { event = "Error"
+        } else if cpReason != nil { event = "Stop"
+        } else if cpSource != nil { event = "SessionStart"
+        } else if cpPrompt != nil { event = "UserPromptSubmit"
+        } else { return nil }
+    }
+
+    // Copilot uses camelCase event names — normalize to PascalCase.
+    if source == "copilot" {
+        let map = [
+            "preToolUse":          "PreToolUse",
+            "postToolUse":         "PostToolUse",
+            "userPromptSubmitted": "UserPromptSubmit",
+            "sessionStart":        "SessionStart",
+            "sessionEnd":          "SessionEnd",
+            "errorOccurred":       "Error",
+        ]
+        if let mapped = map[event] { event = mapped }
+    }
+
+    // Copilot tool names are lowercase; normalize.
+    let toolNameMap = [
+        "edit": "Edit", "create": "Write", "view": "Read", "bash": "Bash",
+        "grep": "Grep", "glob": "Glob", "agent": "Agent",
+    ]
+    tool = toolNameMap[tool] ?? tool
+
+    let cwd = (payload["cwd"] as? String) ?? ""
+    let project = cwd.isEmpty ? "" : (cwd as NSString).lastPathComponent
+    let agentId = payload["agent_id"] as? String
+    let agentType = payload["agent_type"] as? String
+    let hasAgent = !(agentId ?? "").isEmpty && !(agentType ?? "").isEmpty
+    let displayProject = hasAgent ? "↳ \(agentType!)" : project
+
+    let toolInput = (payload["tool_input"] as? [String: Any]) ?? [:]
+
+    let copilotToolArgs: [String: Any] = {
+        guard let s = payload["toolArgs"] as? String,
+              let data = s.data(using: .utf8),
+              let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return [:] }
+        return dict
+    }()
+
+    return HookPlan(
+        payload: payload, source: source, event: event, tool: tool,
+        cwd: cwd, project: project, displayProject: displayProject,
+        agentId: agentId, agentType: agentType,
+        toolInput: toolInput, copilotToolArgs: copilotToolArgs,
+        cpError: cpError
+    )
+}
+
+extension HookPlan {
+    /// Whether this PreToolUse should cache its payload to /tmp for the next
+    /// PermissionRequest to read (FIFO context correlation).
+    public var shouldCachePreToolUse: Bool {
+        ["Edit", "Write", "Bash", "MultiEdit", "NotebookEdit"].contains(tool)
+    }
+
+    /// Adds project / agent / source fields common to every event.
+    public func decorate(_ base: [String: Any]) -> [String: Any] {
+        var p = base
+        if !displayProject.isEmpty { p["project"] = displayProject }
+        if let id = agentId, !id.isEmpty { p["agent_id"] = id }
+        if let t = agentType, !t.isEmpty { p["agent_type"] = t }
+        if !source.isEmpty { p["source"] = source }
+        return p
+    }
+
+    public func toolInputString(_ key: String) -> String {
+        (toolInput[key] as? String) ?? ""
+    }
+
+    /// File path — tries Claude's `tool_input.file_path` then Copilot's
+    /// `toolArgs.{file_path|path|filePath}`.
+    public var filePath: String {
+        let f = toolInputString("file_path")
+        if !f.isEmpty { return f }
+        for key in ["file_path", "path", "filePath"] {
+            if let v = copilotToolArgs[key] as? String, !v.isEmpty { return v }
+        }
+        return ""
+    }
+
+    /// Bash command — tries Claude's `tool_input.command` then Copilot's
+    /// `toolArgs.command`.
+    public var command: String {
+        let c = toolInputString("command")
+        if !c.isEmpty { return c }
+        return (copilotToolArgs["command"] as? String) ?? ""
+    }
+}

--- a/Sources/IslandHookCore/PayloadBuilder.swift
+++ b/Sources/IslandHookCore/PayloadBuilder.swift
@@ -1,0 +1,245 @@
+import Foundation
+
+/// Build the island event payload for a PreToolUse. Decorated with
+/// project/agent/source already — callers can POST directly.
+public func buildPreToolUsePayload(_ plan: HookPlan) -> [String: Any] {
+    switch plan.tool {
+    case "Edit":
+        let fname = basename(plan.filePath)
+        var oldStr = plan.toolInputString("old_string")
+        var newStr = plan.toolInputString("new_string")
+        // MultiEdit fallback — sniff first edit
+        if oldStr.isEmpty && newStr.isEmpty,
+           let edits = plan.toolInput["edits"] as? [[String: Any]],
+           let first = edits.first {
+            oldStr = (first["old_string"] as? String) ?? ""
+            newStr = (first["new_string"] as? String) ?? ""
+        }
+        let diff = buildEditDiff(old: oldStr, new: newStr)
+        var p: [String: Any] = [
+            "title": "Editing", "subtitle": fname.isEmpty ? "file" : fname,
+            "style": "claude", "duration": 3,
+        ]
+        if !diff.isEmpty { p["detail"] = diff }
+        return plan.decorate(p)
+
+    case "Write":
+        let fname = basename(plan.filePath)
+        var content = plan.toolInputString("content")
+        if content.isEmpty { content = (plan.copilotToolArgs["content"] as? String) ?? "" }
+        var p: [String: Any] = [
+            "title": "Writing", "subtitle": fname.isEmpty ? "file" : fname,
+            "style": "claude", "duration": 3,
+        ]
+        if !content.isEmpty { p["detail"] = diffLines(content, prefix: "+ ") }
+        return plan.decorate(p)
+
+    case "Read":
+        let fname = basename(plan.filePath)
+        return plan.decorate([
+            "title": "Reading", "subtitle": fname.isEmpty ? "file" : fname,
+            "style": "claude", "duration": 2,
+        ])
+
+    case "Bash":
+        let cmd = plan.command
+        let desc = plan.toolInputString("description")
+        let display = truncate(desc.isEmpty ? cmd : desc, 35)
+        return plan.decorate([
+            "title": "Terminal", "subtitle": display,
+            "style": "claude", "duration": 3,
+        ])
+
+    case "Grep":
+        var pattern = plan.toolInputString("pattern")
+        if pattern.isEmpty { pattern = (plan.copilotToolArgs["pattern"] as? String) ?? "" }
+        return plan.decorate([
+            "title": "Searching", "subtitle": truncate(pattern, 30),
+            "style": "claude", "duration": 2,
+        ])
+
+    case "Glob":
+        var pattern = plan.toolInputString("pattern")
+        if pattern.isEmpty { pattern = (plan.copilotToolArgs["pattern"] as? String) ?? "" }
+        return plan.decorate([
+            "title": "Finding files", "subtitle": pattern,
+            "style": "claude", "duration": 2,
+        ])
+
+    case "Agent":
+        let desc = plan.toolInputString("description")
+        let agentTy = plan.toolInputString("subagent_type").isEmpty
+            ? "agent"
+            : plan.toolInputString("subagent_type")
+        return plan.decorate([
+            "title": "Agent", "subtitle": truncate(desc.isEmpty ? agentTy : desc, 35),
+            "style": "claude", "duration": 3,
+        ])
+
+    default:
+        let display = plan.tool.replacingOccurrences(
+            of: #"^mcp__[^_]*__"#, with: "", options: .regularExpression
+        )
+        return plan.decorate([
+            "title": display, "style": "claude", "duration": 2,
+        ])
+    }
+}
+
+/// Returns nil if nothing to emit for this PostToolUse.
+public func buildPostToolUsePayload(_ plan: HookPlan) -> [String: Any]? {
+    switch plan.tool {
+    case "Edit", "Write":
+        let fname = basename(plan.filePath)
+        return plan.decorate([
+            "title": "Saved", "subtitle": fname.isEmpty ? "file" : fname,
+            "style": "success", "duration": 1.5,
+        ])
+    default:
+        return nil
+    }
+}
+
+public func buildPostToolUseFailurePayload(_ plan: HookPlan) -> [String: Any] {
+    let err = (plan.payload["tool_error"] as? String)
+        ?? (plan.payload["error"] as? String) ?? ""
+    let trimmed = String(err.prefix(60))
+    return plan.decorate([
+        "title": "Tool failed",
+        "subtitle": trimmed.isEmpty ? plan.tool : trimmed,
+        "style": "error", "duration": 5,
+    ])
+}
+
+public func buildPermissionDeniedPayload(_ plan: HookPlan) -> [String: Any] {
+    let toolName = (plan.payload["tool_name"] as? String) ?? "tool"
+    let reason = String(((plan.payload["denial_reason"] as? String) ?? "").prefix(60))
+    return plan.decorate([
+        "title": "Denied",
+        "subtitle": reason.isEmpty ? toolName : reason,
+        "style": "warning", "duration": 4,
+    ])
+}
+
+/// Returns nil when this is a permission_prompt Notification that we want
+/// to ignore (the real PermissionRequest hook will show Allow/Deny).
+public func buildNotificationPayload(_ plan: HookPlan) -> [String: Any]? {
+    let notifType = (plan.payload["notification_type"] as? String) ?? ""
+    if notifType == "permission_prompt" { return nil }
+    let msg = (plan.payload["message"] as? String) ?? "Notification"
+    return plan.decorate([
+        "title": "Claude Code", "subtitle": truncate(msg, 45), "style": "reminder",
+    ])
+}
+
+/// Build the PermissionRequest dialog payload. If cached PreToolUse input
+/// is provided and matches the tool, enriches the detail with a diff or
+/// content preview.
+public func buildPermissionRequestPayload(
+    _ plan: HookPlan,
+    cachedInput: [String: Any]? = nil,
+    cachedToolName: String? = nil
+) -> [String: Any] {
+    let toolName = (plan.payload["tool_name"] as? String) ?? "tool"
+    var toolDetail = String(
+        (plan.toolInputString("command").isEmpty
+            ? plan.toolInputString("file_path")
+            : plan.toolInputString("command")
+        ).prefix(40)
+    )
+
+    var diff = ""
+    if let input = cachedInput, cachedToolName == toolName {
+        switch toolName {
+        case "Edit", "MultiEdit":
+            var oldStr = (input["old_string"] as? String) ?? ""
+            var newStr = (input["new_string"] as? String) ?? ""
+            if oldStr.isEmpty && newStr.isEmpty,
+               let edits = input["edits"] as? [[String: Any]], let first = edits.first {
+                oldStr = (first["old_string"] as? String) ?? ""
+                newStr = (first["new_string"] as? String) ?? ""
+            }
+            diff = buildEditDiff(old: oldStr, new: newStr)
+        case "Write":
+            let content = (input["content"] as? String) ?? ""
+            if !content.isEmpty { diff = diffLines(content, prefix: "+ ") }
+        case "Bash":
+            if toolDetail.isEmpty {
+                let cmd = (input["description"] as? String)
+                    ?? (input["command"] as? String) ?? ""
+                toolDetail = String(cmd.prefix(40))
+            }
+        default: break
+        }
+    }
+
+    var p: [String: Any] = [
+        "title": "Permission",
+        "subtitle": "\(toolName): \(toolDetail)",
+        "style": "action",
+    ]
+    if !diff.isEmpty { p["detail"] = diff }
+    return plan.decorate(p)
+}
+
+public func buildStopPayload(_ plan: HookPlan) -> [String: Any] {
+    let lastMsg = (plan.payload["last_assistant_message"] as? String) ?? ""
+    let tail = String(lastMsg.suffix(200))
+    if tail.range(of: #"[?？]\s*$"#, options: .regularExpression) != nil {
+        return plan.decorate([
+            "title": "Waiting", "subtitle": "Your turn", "style": "reminder",
+        ])
+    } else {
+        return plan.decorate([
+            "title": "Done", "style": "success", "duration": 3,
+        ])
+    }
+}
+
+public func buildStopFailurePayload(_ plan: HookPlan) -> [String: Any] {
+    let err = String(((plan.payload["stop_error"] as? String) ?? "").prefix(60))
+    return plan.decorate([
+        "title": "Error", "subtitle": err.isEmpty ? "API error" : err,
+        "style": "error", "duration": 6,
+    ])
+}
+
+public func buildErrorPayload(_ plan: HookPlan) -> [String: Any] {
+    return plan.decorate([
+        "title": "Error", "subtitle": truncate(plan.cpError ?? "", 35),
+        "style": "error", "duration": 5,
+    ])
+}
+
+public func buildSubagentStartPayload(_ plan: HookPlan) -> [String: Any] {
+    let agentTy = (plan.payload["agent_type"] as? String) ?? "agent"
+    return plan.decorate([
+        "title": "Agent", "subtitle": agentTy, "style": "claude", "duration": 3,
+    ])
+}
+
+public func buildSubagentStopPayload(_ plan: HookPlan) -> [String: Any] {
+    let agentTy = (plan.payload["agent_type"] as? String) ?? "agent"
+    return plan.decorate([
+        "title": "Agent done", "subtitle": agentTy, "style": "success", "duration": 2,
+    ])
+}
+
+public func buildSessionStartPayload(_ plan: HookPlan) -> [String: Any] {
+    let src = (plan.payload["source"] as? String) ?? "startup"
+    return plan.decorate([
+        "title": "Session", "subtitle": src, "style": "info", "duration": 2,
+    ])
+}
+
+public func buildPreCompactPayload(_ plan: HookPlan) -> [String: Any] {
+    return plan.decorate([
+        "title": "Compacting", "subtitle": "context", "style": "info", "duration": 2,
+    ])
+}
+
+public func buildPostCompactPayload(_ plan: HookPlan) -> [String: Any] {
+    return plan.decorate([
+        "title": "Compacted", "style": "success", "duration": 2,
+    ])
+}

--- a/Sources/island-hook/main.swift
+++ b/Sources/island-hook/main.swift
@@ -1,112 +1,36 @@
 // island-hook — universal hook binary that replaces hooks/island-hook.sh.
 // Reads a Claude Code / Copilot / Codex hook payload from stdin, formats an
-// island event, and POSTs it to the running Dynamic Island app on
-// 127.0.0.1:9423. Foundation-only so the deployed binary stays small and
-// the user no longer needs `jq` installed.
+// island event (via IslandHookCore), and POSTs it to the running Dynamic
+// Island app on 127.0.0.1:9423.
 //
 // PermissionRequest is the only event that produces stdout: it long-polls
 // /response and emits the JSON allow/deny decision Claude Code expects.
 
 import Foundation
-
-// MARK: - Constants
+import IslandHookCore
 
 let port = ProcessInfo.processInfo.environment["DYNAMIC_ISLAND_PORT"]
     .flatMap(Int.init) ?? 9423
 let eventURL = URL(string: "http://127.0.0.1:\(port)/event")!
 let responseURL = URL(string: "http://127.0.0.1:\(port)/response")!
 
-// MARK: - Read stdin
+// MARK: - Parse stdin
 
 let inputData = FileHandle.standardInput.readDataToEndOfFile()
 guard !inputData.isEmpty,
       let jsonAny = try? JSONSerialization.jsonObject(with: inputData),
-      let payload = jsonAny as? [String: Any] else {
-    exit(0)
-}
+      let payload = jsonAny as? [String: Any],
+      let plan = parseHookPlan(payload: payload, env: ProcessInfo.processInfo.environment)
+else { exit(0) }
 
-// MARK: - Source & event detection
-//
-// SOURCE drives the project color:
-//   claude  → warm orange    copilot → GitHub violet    codex → OpenAI green
-// Override via ISLAND_SOURCE env var (Codex hook script should set this).
+// MARK: - I/O helpers
 
-var source = ProcessInfo.processInfo.environment["ISLAND_SOURCE"] ?? ""
-
-let ccEvent = payload["hook_event_name"] as? String
-let cpTool = payload["toolName"] as? String
-let cpPrompt = payload["prompt"] as? String
-let cpSource = payload["source"] as? String
-let cpReason = payload["reason"] as? String
-let cpError: String? = (payload["error"] as? [String: Any])?["message"] as? String
-
-var event = ""
-var tool = ""
-
-if let ccEvent = ccEvent {
-    event = ccEvent
-    tool = (payload["tool_name"] as? String) ?? ""
-    // First-letter casing distinguishes Claude (PascalCase) from Copilot CLI (camelCase).
-    if source.isEmpty {
-        source = (ccEvent.first?.isUppercase ?? true) ? "claude" : "copilot"
-    }
-} else {
-    if source.isEmpty { source = "copilot" }
-    if let cpTool = cpTool {
-        let resultType = (payload["toolResult"] as? [String: Any])?["resultType"] as? String
-        event = (resultType != nil) ? "PostToolUse" : "PreToolUse"
-        tool = cpTool
-    } else if cpError != nil { event = "Error"
-    } else if cpReason != nil { event = "Stop"
-    } else if cpSource != nil { event = "SessionStart"
-    } else if cpPrompt != nil { event = "UserPromptSubmit"
-    } else { exit(0) }
-}
-
-// Copilot uses camelCase event names — normalize to the PascalCase forms we switch on.
-if source == "copilot" {
-    let map = [
-        "preToolUse":          "PreToolUse",
-        "postToolUse":         "PostToolUse",
-        "userPromptSubmitted": "UserPromptSubmit",
-        "sessionStart":        "SessionStart",
-        "sessionEnd":          "SessionEnd",
-        "errorOccurred":       "Error",
-    ]
-    if let mapped = map[event] { event = mapped }
-}
-
-// Copilot tool names are lowercase; normalize.
-let toolNameMap = [
-    "edit": "Edit", "create": "Write", "view": "Read", "bash": "Bash",
-    "grep": "Grep", "glob": "Glob", "agent": "Agent",
-]
-tool = toolNameMap[tool] ?? tool
-
-// MARK: - Project / subagent labels
-
-let cwd = (payload["cwd"] as? String) ?? ""
-let project = cwd.isEmpty ? "" : (cwd as NSString).lastPathComponent
-let agentId = payload["agent_id"] as? String
-let agentType = payload["agent_type"] as? String
-let hasAgent = !(agentId ?? "").isEmpty && !(agentType ?? "").isEmpty
-let displayProject: String = hasAgent ? "↳ \(agentType!)" : project
-
-// MARK: - Helpers
-
-func send(_ extra: [String: Any]) {
-    var p = extra
-    if !displayProject.isEmpty { p["project"] = displayProject }
-    if let id = agentId, !id.isEmpty { p["agent_id"] = id }
-    if let t  = agentType, !t.isEmpty { p["agent_type"] = t }
-    if !source.isEmpty { p["source"] = source }
-
-    guard let body = try? JSONSerialization.data(withJSONObject: p) else { return }
-
+func send(_ body: [String: Any]) {
+    guard let data = try? JSONSerialization.data(withJSONObject: body) else { return }
     var req = URLRequest(url: eventURL)
     req.httpMethod = "POST"
     req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    req.httpBody = body
+    req.httpBody = data
     req.timeoutInterval = 3
 
     let sem = DispatchSemaphore(value: 0)
@@ -114,11 +38,9 @@ func send(_ extra: [String: Any]) {
     _ = sem.wait(timeout: .now() + 3)
 }
 
-/// Synchronous GET /response with timeout — returns "allow", "deny", or "timeout".
 func longPollResponse(timeoutSeconds: TimeInterval) -> String {
     var req = URLRequest(url: responseURL)
     req.timeoutInterval = timeoutSeconds + 1
-
     var decision = "timeout"
     let sem = DispatchSemaphore(value: 0)
     URLSession.shared.dataTask(with: req) { data, _, _ in
@@ -132,69 +54,9 @@ func longPollResponse(timeoutSeconds: TimeInterval) -> String {
     return decision
 }
 
-func truncate(_ s: String, _ max: Int) -> String {
-    s.count > max ? String(s.prefix(max)) + "…" : s
-}
+// MARK: - FIFO context cache
 
-func basename(_ path: String) -> String {
-    (path as NSString).lastPathComponent
-}
-
-/// Trim a multi-line string to first N lines, each truncated to ~maxChars,
-/// each prefixed by `prefix`. Appends "(+K more)" if lines were dropped.
-func diffLines(_ text: String, prefix: String, maxLines: Int = 5, maxChars: Int = 80) -> String {
-    let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-    var out: [String] = []
-    for line in lines.prefix(maxLines) {
-        out.append(prefix + (line.count > maxChars ? String(line.prefix(maxChars)) + "…" : line))
-    }
-    if lines.count > maxLines {
-        out.append("  (+\(lines.count - maxLines) more)")
-    }
-    return out.joined(separator: "\n")
-}
-
-func buildEditDiff(old: String, new: String) -> String {
-    var parts: [String] = []
-    if !old.isEmpty { parts.append(diffLines(old, prefix: "- ")) }
-    if !new.isEmpty { parts.append(diffLines(new, prefix: "+ ")) }
-    return parts.joined(separator: "\n")
-}
-
-// MARK: - Tool input extraction (handles both Claude Code and Copilot shapes)
-
-let toolInput: [String: Any] = (payload["tool_input"] as? [String: Any]) ?? [:]
-
-let copilotToolArgs: [String: Any] = {
-    guard let s = payload["toolArgs"] as? String,
-          let data = s.data(using: .utf8),
-          let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-    else { return [:] }
-    return dict
-}()
-
-func toolInputString(_ key: String) -> String {
-    (toolInput[key] as? String) ?? ""
-}
-
-func getFile() -> String {
-    let f = toolInputString("file_path")
-    if !f.isEmpty { return f }
-    for key in ["file_path", "path", "filePath"] {
-        if let v = copilotToolArgs[key] as? String, !v.isEmpty { return v }
-    }
-    return ""
-}
-
-func getCommand() -> String {
-    let c = toolInputString("command")
-    if !c.isEmpty { return c }
-    return (copilotToolArgs["command"] as? String) ?? ""
-}
-
-// MARK: - FIFO context cache for permission diff preview
-
-let contextFile = "/tmp/di_pretool_\(project.isEmpty ? "default" : project).json"
+let contextFile = "/tmp/di_pretool_\(plan.project.isEmpty ? "default" : plan.project).json"
 
 func writeContextCache() {
     try? inputData.write(to: URL(fileURLWithPath: contextFile))
@@ -210,271 +72,78 @@ func readCachedToolInput() -> (toolName: String, input: [String: Any])? {
     return (name, input)
 }
 
-// MARK: - Event handlers
+// MARK: - Dispatch
 
-func handlePreToolUse() {
-    switch tool {
-    case "Edit":
-        let fname = basename(getFile())
-        var oldStr = toolInputString("old_string")
-        var newStr = toolInputString("new_string")
-        // MultiEdit fallback — sniff first edit
-        if oldStr.isEmpty && newStr.isEmpty,
-           let edits = toolInput["edits"] as? [[String: Any]],
-           let first = edits.first {
-            oldStr = (first["old_string"] as? String) ?? ""
-            newStr = (first["new_string"] as? String) ?? ""
-        }
-        let diff = buildEditDiff(old: oldStr, new: newStr)
-        var p: [String: Any] = [
-            "title": "Editing", "subtitle": fname.isEmpty ? "file" : fname,
-            "style": "claude", "duration": 3,
-        ]
-        if !diff.isEmpty { p["detail"] = diff }
-        send(p)
+switch plan.event {
+case "PreToolUse":
+    send(buildPreToolUsePayload(plan))
+    if plan.shouldCachePreToolUse { writeContextCache() }
 
-    case "Write":
-        let fname = basename(getFile())
-        var content = toolInputString("content")
-        if content.isEmpty { content = (copilotToolArgs["content"] as? String) ?? "" }
-        var p: [String: Any] = [
-            "title": "Writing", "subtitle": fname.isEmpty ? "file" : fname,
-            "style": "claude", "duration": 3,
-        ]
-        if !content.isEmpty { p["detail"] = diffLines(content, prefix: "+ ") }
-        send(p)
+case "PostToolUse":
+    if let body = buildPostToolUsePayload(plan) { send(body) }
 
-    case "Read":
-        let fname = basename(getFile())
-        send([
-            "title": "Reading", "subtitle": fname.isEmpty ? "file" : fname,
-            "style": "claude", "duration": 2,
-        ])
+case "PostToolUseFailure":
+    send(buildPostToolUseFailurePayload(plan))
 
-    case "Bash":
-        let cmd = getCommand()
-        let desc = toolInputString("description")
-        let display = truncate(desc.isEmpty ? cmd : desc, 35)
-        send([
-            "title": "Terminal", "subtitle": display,
-            "style": "claude", "duration": 3,
-        ])
+case "PermissionDenied":
+    send(buildPermissionDeniedPayload(plan))
 
-    case "Grep":
-        var pattern = toolInputString("pattern")
-        if pattern.isEmpty { pattern = (copilotToolArgs["pattern"] as? String) ?? "" }
-        send([
-            "title": "Searching", "subtitle": truncate(pattern, 30),
-            "style": "claude", "duration": 2,
-        ])
+case "Notification":
+    if let body = buildNotificationPayload(plan) { send(body) }
 
-    case "Glob":
-        var pattern = toolInputString("pattern")
-        if pattern.isEmpty { pattern = (copilotToolArgs["pattern"] as? String) ?? "" }
-        send([
-            "title": "Finding files", "subtitle": pattern,
-            "style": "claude", "duration": 2,
-        ])
-
-    case "Agent":
-        let desc = toolInputString("description")
-        let agentTy = toolInputString("subagent_type").isEmpty ? "agent" : toolInputString("subagent_type")
-        send([
-            "title": "Agent", "subtitle": truncate(desc.isEmpty ? agentTy : desc, 35),
-            "style": "claude", "duration": 3,
-        ])
-
-    default:
-        let display = tool.replacingOccurrences(of: #"^mcp__[^_]*__"#, with: "", options: .regularExpression)
-        send([
-            "title": display, "style": "claude", "duration": 2,
-        ])
-    }
-
-    // Cache for FIFO correlation with the next PermissionRequest.
-    if ["Edit", "Write", "Bash", "MultiEdit", "NotebookEdit"].contains(tool) {
-        writeContextCache()
-    }
-}
-
-func handlePostToolUse() {
-    switch tool {
-    case "Edit", "Write":
-        let fname = basename(getFile())
-        send([
-            "title": "Saved", "subtitle": fname.isEmpty ? "file" : fname,
-            "style": "success", "duration": 1.5,
-        ])
-    default:
-        break
-    }
-}
-
-func handlePostToolUseFailure() {
-    let err = (payload["tool_error"] as? String) ?? (payload["error"] as? String) ?? ""
-    let trimmed = String(err.prefix(60))
-    send([
-        "title": "Tool failed",
-        "subtitle": trimmed.isEmpty ? tool : trimmed,
-        "style": "error", "duration": 5,
-    ])
-}
-
-func handlePermissionDenied() {
-    let toolName = (payload["tool_name"] as? String) ?? "tool"
-    let reason = String(((payload["denial_reason"] as? String) ?? "").prefix(60))
-    send([
-        "title": "Denied",
-        "subtitle": reason.isEmpty ? toolName : reason,
-        "style": "warning", "duration": 4,
-    ])
-}
-
-func handleNotification() {
-    let notifType = (payload["notification_type"] as? String) ?? ""
-    if notifType == "permission_prompt" { return } // PermissionRequest handles real buttons
-    let msg = (payload["message"] as? String) ?? "Notification"
-    send([
-        "title": "Claude Code", "subtitle": truncate(msg, 45), "style": "reminder",
-    ])
-}
-
-func handlePermissionRequest() -> Never {
-    let toolName = (payload["tool_name"] as? String) ?? "tool"
-    var toolDetail = String(
-        (toolInputString("command").isEmpty ? toolInputString("file_path") : toolInputString("command"))
-            .prefix(40)
+case "PermissionRequest":
+    let cached = readCachedToolInput()
+    let body = buildPermissionRequestPayload(
+        plan,
+        cachedInput: cached?.input,
+        cachedToolName: cached?.toolName
     )
+    send(body)
 
-    // FIFO correlation: enrich dialog with diff/content from preceding PreToolUse
-    var diff = ""
-    if let cached = readCachedToolInput(), cached.toolName == toolName {
-        let input = cached.input
-        switch toolName {
-        case "Edit", "MultiEdit":
-            var oldStr = (input["old_string"] as? String) ?? ""
-            var newStr = (input["new_string"] as? String) ?? ""
-            if oldStr.isEmpty && newStr.isEmpty,
-               let edits = input["edits"] as? [[String: Any]], let first = edits.first {
-                oldStr = (first["old_string"] as? String) ?? ""
-                newStr = (first["new_string"] as? String) ?? ""
-            }
-            diff = buildEditDiff(old: oldStr, new: newStr)
-        case "Write":
-            let content = (input["content"] as? String) ?? ""
-            if !content.isEmpty { diff = diffLines(content, prefix: "+ ") }
-        case "Bash":
-            if toolDetail.isEmpty {
-                let cmd = (input["description"] as? String) ?? (input["command"] as? String) ?? ""
-                toolDetail = String(cmd.prefix(40))
-            }
-        default: break
-        }
-    }
-
-    var p: [String: Any] = [
-        "title": "Permission",
-        "subtitle": "\(toolName): \(toolDetail)",
-        "style": "action",
-    ]
-    if !diff.isEmpty { p["detail"] = diff }
-    send(p)
-
-    let decision = longPollResponse(timeoutSeconds: 25)
-    switch decision {
+    switch longPollResponse(timeoutSeconds: 25) {
     case "allow":
         print(#"{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}"#)
     case "deny":
         print(#"{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"deny","message":"Denied from Dynamic Island"}}}"#)
-    default:
-        break // timeout: silently defer to Claude Code's normal flow
+    default: break
     }
     exit(0)
-}
 
-func handleStop() {
+case "Stop":
     send(["type": "thinking_stop"])
-    let lastMsg = (payload["last_assistant_message"] as? String) ?? ""
-    let tail = String(lastMsg.suffix(200))
-    if tail.range(of: #"[?？]\s*$"#, options: .regularExpression) != nil {
-        send(["title": "Waiting", "subtitle": "Your turn", "style": "reminder"])
-    } else {
-        send(["title": "Done", "style": "success", "duration": 3])
-    }
-}
+    send(buildStopPayload(plan))
 
-func handleStopFailure() {
+case "StopFailure":
     send(["type": "thinking_stop"])
-    let err = String(((payload["stop_error"] as? String) ?? "").prefix(60))
-    send([
-        "title": "Error", "subtitle": err.isEmpty ? "API error" : err,
-        "style": "error", "duration": 6,
-    ])
-}
+    send(buildStopFailurePayload(plan))
 
-func handleError() {
+case "Error":
     send(["type": "thinking_stop"])
-    send([
-        "title": "Error", "subtitle": truncate(cpError ?? "", 35),
-        "style": "error", "duration": 5,
-    ])
-}
+    send(buildErrorPayload(plan))
 
-func handleSubagentStart() {
-    let agentTy = (payload["agent_type"] as? String) ?? "agent"
-    send([
-        "title": "Agent", "subtitle": agentTy, "style": "claude", "duration": 3,
-    ])
-}
+case "SubagentStart":
+    send(buildSubagentStartPayload(plan))
 
-func handleSubagentStop() {
-    let agentTy = (payload["agent_type"] as? String) ?? "agent"
+case "SubagentStop":
     send(["type": "subagent_stop"])
-    send([
-        "title": "Agent done", "subtitle": agentTy, "style": "success", "duration": 2,
-    ])
-}
+    send(buildSubagentStopPayload(plan))
 
-func handleSessionStart() {
-    let src = (payload["source"] as? String) ?? "startup"
-    send(["title": "Session", "subtitle": src, "style": "info", "duration": 2])
-}
+case "SessionStart":
+    send(buildSessionStartPayload(plan))
 
-func handleSessionEnd() {
+case "SessionEnd":
     send(["type": "thinking_stop"])
-}
 
-func handlePreCompact() {
-    send(["title": "Compacting", "subtitle": "context", "style": "info", "duration": 2])
-}
+case "PreCompact":
+    send(buildPreCompactPayload(plan))
 
-func handlePostCompact() {
-    send(["title": "Compacted", "style": "success", "duration": 2])
-}
+case "PostCompact":
+    send(buildPostCompactPayload(plan))
 
-func handleUserPromptSubmit() {
+case "UserPromptSubmit":
     send(["type": "thinking_start"])
+
+default: break
 }
 
-// MARK: - Dispatch
-
-switch event {
-case "PreToolUse":         handlePreToolUse()
-case "PostToolUse":        handlePostToolUse()
-case "PostToolUseFailure": handlePostToolUseFailure()
-case "PermissionRequest":  handlePermissionRequest()
-case "PermissionDenied":   handlePermissionDenied()
-case "Notification":       handleNotification()
-case "Stop":               handleStop()
-case "StopFailure":        handleStopFailure()
-case "Error":              handleError()
-case "SubagentStart":      handleSubagentStart()
-case "SubagentStop":       handleSubagentStop()
-case "SessionStart":       handleSessionStart()
-case "SessionEnd":         handleSessionEnd()
-case "PreCompact":         handlePreCompact()
-case "PostCompact":        handlePostCompact()
-case "UserPromptSubmit":   handleUserPromptSubmit()
-default: exit(0)
-}
 exit(0)

--- a/Tests/IslandHookCoreTests/FormatTests.swift
+++ b/Tests/IslandHookCoreTests/FormatTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import IslandHookCore
+
+final class FormatTests: XCTestCase {
+
+    // MARK: - truncate
+
+    func testTruncate_shortString_unchanged() {
+        XCTAssertEqual(truncate("hi", 10), "hi")
+    }
+
+    func testTruncate_exactlyMax_unchanged() {
+        XCTAssertEqual(truncate("abcde", 5), "abcde")
+    }
+
+    func testTruncate_longer_addsEllipsis() {
+        XCTAssertEqual(truncate("abcdefgh", 5), "abcde…")
+    }
+
+    func testTruncate_empty() {
+        XCTAssertEqual(truncate("", 5), "")
+    }
+
+    // MARK: - basename
+
+    func testBasename_absolutePath() {
+        XCTAssertEqual(basename("/Users/bistin/projects/foo.swift"), "foo.swift")
+    }
+
+    func testBasename_justName() {
+        XCTAssertEqual(basename("file.txt"), "file.txt")
+    }
+
+    func testBasename_trailingSlashGone() {
+        XCTAssertEqual(basename("/tmp/dir/"), "dir")
+    }
+
+    // MARK: - diffLines
+
+    func testDiffLines_empty_returnsEmpty() {
+        XCTAssertEqual(diffLines("", prefix: "- "), "")
+    }
+
+    func testDiffLines_singleLine() {
+        XCTAssertEqual(diffLines("hello", prefix: "+ "), "+ hello")
+    }
+
+    func testDiffLines_multiLineAllFit() {
+        let input = "one\ntwo\nthree"
+        XCTAssertEqual(diffLines(input, prefix: "- "), "- one\n- two\n- three")
+    }
+
+    func testDiffLines_exceedsMaxLines_appendsMoreCount() {
+        let input = "a\nb\nc\nd\ne\nf\ng"   // 7 lines, default max 5
+        let out = diffLines(input, prefix: "+ ")
+        XCTAssertTrue(out.contains("+ a"))
+        XCTAssertTrue(out.contains("+ e"))
+        XCTAssertFalse(out.contains("+ f"))
+        XCTAssertTrue(out.hasSuffix("  (+2 more)"))
+    }
+
+    func testDiffLines_longLine_truncated() {
+        let input = String(repeating: "x", count: 100) // > default maxChars 80
+        let out = diffLines(input, prefix: "- ")
+        XCTAssertTrue(out.hasSuffix("…"))
+        XCTAssertTrue(out.count < input.count + 2) // sanity: fewer than full len
+    }
+
+    // MARK: - buildEditDiff
+
+    func testBuildEditDiff_bothSides() {
+        let out = buildEditDiff(old: "let x = 1", new: "let x = 42")
+        XCTAssertEqual(out, "- let x = 1\n+ let x = 42")
+    }
+
+    func testBuildEditDiff_onlyNew() {
+        XCTAssertEqual(buildEditDiff(old: "", new: "new"), "+ new")
+    }
+
+    func testBuildEditDiff_onlyOld() {
+        XCTAssertEqual(buildEditDiff(old: "gone", new: ""), "- gone")
+    }
+
+    func testBuildEditDiff_bothEmpty() {
+        XCTAssertEqual(buildEditDiff(old: "", new: ""), "")
+    }
+
+    func testBuildEditDiff_multiLineOldNew() {
+        let out = buildEditDiff(old: "foo\nbar", new: "FOO\nBAR")
+        XCTAssertEqual(out, "- foo\n- bar\n+ FOO\n+ BAR")
+    }
+}

--- a/Tests/IslandHookCoreTests/HookPlanTests.swift
+++ b/Tests/IslandHookCoreTests/HookPlanTests.swift
@@ -1,0 +1,179 @@
+import XCTest
+@testable import IslandHookCore
+
+final class HookPlanTests: XCTestCase {
+
+    // MARK: - Source detection
+
+    func testClaudeCode_PascalCaseEvent() {
+        let plan = parseHookPlan(payload: [
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "cwd": "/Users/bistin/projects/demo",
+        ])
+        XCTAssertEqual(plan?.source, "claude")
+        XCTAssertEqual(plan?.event, "PreToolUse")
+        XCTAssertEqual(plan?.tool, "Bash")
+        XCTAssertEqual(plan?.project, "demo")
+    }
+
+    func testCopilotCLI_camelCaseEventNormalizedToPascalCase() {
+        let plan = parseHookPlan(payload: [
+            "hook_event_name": "preToolUse",
+            "tool_name": "bash",
+            "cwd": "/tmp/cp-demo",
+        ])
+        XCTAssertEqual(plan?.source, "copilot")
+        XCTAssertEqual(plan?.event, "PreToolUse") // normalized
+        XCTAssertEqual(plan?.tool, "Bash")        // normalized
+    }
+
+    func testCopilotLegacy_toolNameAtRoot() {
+        let plan = parseHookPlan(payload: [
+            "toolName": "edit",
+            "toolArgs": #"{"file_path":"/tmp/a.txt"}"#,
+            "cwd": "/tmp/old-copilot",
+        ])
+        XCTAssertEqual(plan?.source, "copilot")
+        XCTAssertEqual(plan?.event, "PreToolUse")
+        XCTAssertEqual(plan?.tool, "Edit")
+    }
+
+    func testCopilotLegacy_postToolUseWhenResultTypePresent() {
+        let plan = parseHookPlan(payload: [
+            "toolName": "bash",
+            "toolResult": ["resultType": "ok"],
+            "cwd": "/tmp/x",
+        ])
+        XCTAssertEqual(plan?.event, "PostToolUse")
+    }
+
+    func testCodex_envOverrideWins() {
+        let plan = parseHookPlan(
+            payload: ["hook_event_name": "PreToolUse", "cwd": "/tmp/x"],
+            env: ["ISLAND_SOURCE": "codex"]
+        )
+        XCTAssertEqual(plan?.source, "codex")
+    }
+
+    func testUnroutablePayload_returnsNil() {
+        // No hook_event_name, no toolName, no other recognizable field.
+        XCTAssertNil(parseHookPlan(payload: ["cwd": "/tmp"]))
+    }
+
+    // MARK: - Event normalization covers all Copilot events
+
+    func testCopilotEventMap() {
+        let pairs: [(String, String)] = [
+            ("preToolUse", "PreToolUse"),
+            ("postToolUse", "PostToolUse"),
+            ("userPromptSubmitted", "UserPromptSubmit"),
+            ("sessionStart", "SessionStart"),
+            ("sessionEnd", "SessionEnd"),
+            ("errorOccurred", "Error"),
+        ]
+        for (input, expected) in pairs {
+            let plan = parseHookPlan(payload: [
+                "hook_event_name": input, "cwd": "/tmp/x",
+            ])
+            XCTAssertEqual(plan?.event, expected, "Expected \(input) → \(expected)")
+        }
+    }
+
+    // MARK: - Project & subagent labels
+
+    func testProjectFromCwd() {
+        let plan = parseHookPlan(payload: [
+            "hook_event_name": "PreToolUse",
+            "cwd": "/Users/someone/Projects/my-repo",
+        ])
+        XCTAssertEqual(plan?.project, "my-repo")
+        XCTAssertEqual(plan?.displayProject, "my-repo")
+    }
+
+    func testSubagentOverrides_displayProject() {
+        let plan = parseHookPlan(payload: [
+            "hook_event_name": "PreToolUse",
+            "cwd": "/Users/someone/Projects/parent",
+            "agent_id": "abc-123",
+            "agent_type": "Explore",
+        ])
+        XCTAssertEqual(plan?.project, "parent")
+        XCTAssertEqual(plan?.displayProject, "↳ Explore")
+        XCTAssertEqual(plan?.agentId, "abc-123")
+        XCTAssertEqual(plan?.agentType, "Explore")
+    }
+
+    func testEmptyCwd_projectEmpty() {
+        let plan = parseHookPlan(payload: ["hook_event_name": "SessionStart"])
+        XCTAssertEqual(plan?.project, "")
+        XCTAssertEqual(plan?.displayProject, "")
+    }
+
+    // MARK: - Tool input extraction
+
+    func testFilePath_fromClaudeToolInput() {
+        let plan = parseHookPlan(payload: [
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Edit",
+            "tool_input": ["file_path": "/tmp/a.swift"],
+            "cwd": "/tmp/x",
+        ])
+        XCTAssertEqual(plan?.filePath, "/tmp/a.swift")
+    }
+
+    func testFilePath_fromCopilotToolArgs() {
+        let plan = parseHookPlan(payload: [
+            "toolName": "edit",
+            "toolArgs": #"{"file_path":"/tmp/b.txt"}"#,
+            "cwd": "/tmp",
+        ])
+        XCTAssertEqual(plan?.filePath, "/tmp/b.txt")
+    }
+
+    func testCommand_fromClaudeToolInput() {
+        let plan = parseHookPlan(payload: [
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": ["command": "git status"],
+            "cwd": "/tmp",
+        ])
+        XCTAssertEqual(plan?.command, "git status")
+    }
+
+    // MARK: - Decoration
+
+    func testDecorate_addsSourceProjectAgent() {
+        let plan = parseHookPlan(payload: [
+            "hook_event_name": "PreToolUse",
+            "cwd": "/tmp/foo",
+            "agent_id": "xyz",
+            "agent_type": "Plan",
+        ])!
+        let decorated = plan.decorate(["title": "hi"])
+        XCTAssertEqual(decorated["title"] as? String, "hi")
+        XCTAssertEqual(decorated["source"] as? String, "claude")
+        XCTAssertEqual(decorated["project"] as? String, "↳ Plan")
+        XCTAssertEqual(decorated["agent_id"] as? String, "xyz")
+        XCTAssertEqual(decorated["agent_type"] as? String, "Plan")
+    }
+
+    // MARK: - shouldCachePreToolUse
+
+    func testShouldCachePreToolUse() {
+        let cacheable = ["Edit", "Write", "Bash", "MultiEdit", "NotebookEdit"]
+        let notCacheable = ["Read", "Grep", "Glob", "Agent"]
+        for tool in cacheable {
+            let plan = parseHookPlan(payload: [
+                "hook_event_name": "PreToolUse", "tool_name": tool, "cwd": "/tmp",
+            ])
+            XCTAssertTrue(plan?.shouldCachePreToolUse ?? false, "\(tool) should cache")
+        }
+        for tool in notCacheable {
+            let plan = parseHookPlan(payload: [
+                "hook_event_name": "PreToolUse", "tool_name": tool, "cwd": "/tmp",
+            ])
+            XCTAssertFalse(plan?.shouldCachePreToolUse ?? true, "\(tool) should not cache")
+        }
+    }
+}

--- a/Tests/IslandHookCoreTests/PayloadBuilderTests.swift
+++ b/Tests/IslandHookCoreTests/PayloadBuilderTests.swift
@@ -1,0 +1,309 @@
+import XCTest
+@testable import IslandHookCore
+
+final class PayloadBuilderTests: XCTestCase {
+
+    // Helper: build a HookPlan quickly for assertions.
+    private func plan(_ raw: [String: Any], env: [String: String] = [:]) -> HookPlan {
+        guard let p = parseHookPlan(payload: raw, env: env) else {
+            fatalError("Unparseable payload in test")
+        }
+        return p
+    }
+
+    // MARK: - PreToolUse
+
+    func testPreToolUse_Edit_emitsDiffPreview() {
+        let p = plan([
+            "hook_event_name": "PreToolUse", "tool_name": "Edit",
+            "tool_input": [
+                "file_path": "/tmp/x.swift",
+                "old_string": "let x = 1", "new_string": "let x = 42",
+            ],
+            "cwd": "/tmp/demo",
+        ])
+        let body = buildPreToolUsePayload(p)
+        XCTAssertEqual(body["title"] as? String, "Editing")
+        XCTAssertEqual(body["subtitle"] as? String, "x.swift")
+        XCTAssertEqual(body["style"] as? String, "claude")
+        XCTAssertEqual(body["detail"] as? String, "- let x = 1\n+ let x = 42")
+        XCTAssertEqual(body["source"] as? String, "claude")
+    }
+
+    func testPreToolUse_Edit_multiEditFallback() {
+        let p = plan([
+            "hook_event_name": "PreToolUse", "tool_name": "Edit",
+            "tool_input": [
+                "file_path": "/tmp/x.swift",
+                "edits": [
+                    ["old_string": "a", "new_string": "b"] as [String: Any],
+                    ["old_string": "c", "new_string": "d"] as [String: Any],
+                ],
+            ] as [String: Any],
+            "cwd": "/tmp/demo",
+        ])
+        let body = buildPreToolUsePayload(p)
+        XCTAssertEqual(body["detail"] as? String, "- a\n+ b")
+    }
+
+    func testPreToolUse_Edit_emptyFilePath_fallsBackTo_file() {
+        let p = plan([
+            "hook_event_name": "PreToolUse", "tool_name": "Edit",
+            "tool_input": ["old_string": "x", "new_string": "y"],
+            "cwd": "/tmp/demo",
+        ])
+        XCTAssertEqual(buildPreToolUsePayload(p)["subtitle"] as? String, "file")
+    }
+
+    func testPreToolUse_Write_hasContentPreview() {
+        let p = plan([
+            "hook_event_name": "PreToolUse", "tool_name": "Write",
+            "tool_input": [
+                "file_path": "/tmp/w.txt",
+                "content": "hello\nworld",
+            ],
+            "cwd": "/tmp/demo",
+        ])
+        let body = buildPreToolUsePayload(p)
+        XCTAssertEqual(body["title"] as? String, "Writing")
+        XCTAssertEqual(body["detail"] as? String, "+ hello\n+ world")
+    }
+
+    func testPreToolUse_Read_noDetail() {
+        let p = plan([
+            "hook_event_name": "PreToolUse", "tool_name": "Read",
+            "tool_input": ["file_path": "/tmp/r.txt"],
+            "cwd": "/tmp/demo",
+        ])
+        let body = buildPreToolUsePayload(p)
+        XCTAssertEqual(body["title"] as? String, "Reading")
+        XCTAssertEqual(body["subtitle"] as? String, "r.txt")
+        XCTAssertNil(body["detail"])
+    }
+
+    func testPreToolUse_Bash_usesDescription() {
+        let p = plan([
+            "hook_event_name": "PreToolUse", "tool_name": "Bash",
+            "tool_input": ["command": "git status", "description": "Show status"],
+            "cwd": "/tmp/demo",
+        ])
+        let body = buildPreToolUsePayload(p)
+        XCTAssertEqual(body["title"] as? String, "Terminal")
+        XCTAssertEqual(body["subtitle"] as? String, "Show status")
+    }
+
+    func testPreToolUse_Bash_fallsBackToCommandIfNoDescription() {
+        let p = plan([
+            "hook_event_name": "PreToolUse", "tool_name": "Bash",
+            "tool_input": ["command": "ls -la"],
+            "cwd": "/tmp/demo",
+        ])
+        XCTAssertEqual(buildPreToolUsePayload(p)["subtitle"] as? String, "ls -la")
+    }
+
+    func testPreToolUse_Grep_showsPattern() {
+        let p = plan([
+            "hook_event_name": "PreToolUse", "tool_name": "Grep",
+            "tool_input": ["pattern": "TODO"],
+            "cwd": "/tmp/demo",
+        ])
+        let body = buildPreToolUsePayload(p)
+        XCTAssertEqual(body["title"] as? String, "Searching")
+        XCTAssertEqual(body["subtitle"] as? String, "TODO")
+    }
+
+    func testPreToolUse_Agent_fallsBackToAgentTypeIfNoDescription() {
+        let p = plan([
+            "hook_event_name": "PreToolUse", "tool_name": "Agent",
+            "tool_input": ["subagent_type": "Explore"],
+            "cwd": "/tmp/demo",
+        ])
+        XCTAssertEqual(buildPreToolUsePayload(p)["subtitle"] as? String, "Explore")
+    }
+
+    func testPreToolUse_MCP_toolStripsPrefix() {
+        let p = plan([
+            "hook_event_name": "PreToolUse", "tool_name": "mcp__notion__search",
+            "cwd": "/tmp/demo",
+        ])
+        XCTAssertEqual(buildPreToolUsePayload(p)["title"] as? String, "search")
+    }
+
+    // MARK: - PostToolUse
+
+    func testPostToolUse_EditEmitsSaved() {
+        let p = plan([
+            "hook_event_name": "PostToolUse", "tool_name": "Edit",
+            "tool_input": ["file_path": "/tmp/x.swift"],
+            "cwd": "/tmp/demo",
+        ])
+        let body = buildPostToolUsePayload(p)
+        XCTAssertEqual(body?["title"] as? String, "Saved")
+        XCTAssertEqual(body?["subtitle"] as? String, "x.swift")
+        XCTAssertEqual(body?["style"] as? String, "success")
+    }
+
+    func testPostToolUse_ReadReturnsNil() {
+        let p = plan([
+            "hook_event_name": "PostToolUse", "tool_name": "Read",
+            "tool_input": ["file_path": "/tmp/x"],
+            "cwd": "/tmp",
+        ])
+        XCTAssertNil(buildPostToolUsePayload(p))
+    }
+
+    // MARK: - Failure events
+
+    func testPostToolUseFailure_usesToolErrorField() {
+        let p = plan([
+            "hook_event_name": "PostToolUseFailure", "tool_name": "Bash",
+            "tool_error": "exit code 1", "cwd": "/tmp",
+        ])
+        let body = buildPostToolUseFailurePayload(p)
+        XCTAssertEqual(body["title"] as? String, "Tool failed")
+        XCTAssertEqual(body["subtitle"] as? String, "exit code 1")
+        XCTAssertEqual(body["style"] as? String, "error")
+    }
+
+    func testPermissionDenied_withReason() {
+        let p = plan([
+            "hook_event_name": "PermissionDenied", "tool_name": "Edit",
+            "denial_reason": "File outside allowed paths", "cwd": "/tmp",
+        ])
+        let body = buildPermissionDeniedPayload(p)
+        XCTAssertEqual(body["title"] as? String, "Denied")
+        XCTAssertEqual(body["subtitle"] as? String, "File outside allowed paths")
+    }
+
+    func testStopFailure_apiError() {
+        let p = plan([
+            "hook_event_name": "StopFailure", "stop_error": "rate limit", "cwd": "/tmp",
+        ])
+        let body = buildStopFailurePayload(p)
+        XCTAssertEqual(body["title"] as? String, "Error")
+        XCTAssertEqual(body["subtitle"] as? String, "rate limit")
+    }
+
+    func testStopFailure_fallbackWhenErrorMissing() {
+        let p = plan(["hook_event_name": "StopFailure", "cwd": "/tmp"])
+        XCTAssertEqual(buildStopFailurePayload(p)["subtitle"] as? String, "API error")
+    }
+
+    // MARK: - Notification
+
+    func testNotification_permissionPromptSkipped() {
+        let p = plan([
+            "hook_event_name": "Notification",
+            "notification_type": "permission_prompt",
+            "message": "Allow this?",
+            "cwd": "/tmp",
+        ])
+        XCTAssertNil(buildNotificationPayload(p))
+    }
+
+    func testNotification_regularMessageEmits() {
+        let p = plan([
+            "hook_event_name": "Notification",
+            "message": "Something happened",
+            "cwd": "/tmp",
+        ])
+        let body = buildNotificationPayload(p)
+        XCTAssertEqual(body?["title"] as? String, "Claude Code")
+        XCTAssertEqual(body?["subtitle"] as? String, "Something happened")
+        XCTAssertEqual(body?["style"] as? String, "reminder")
+    }
+
+    // MARK: - Stop (asking-question detection)
+
+    func testStop_questionMark_emitsWaiting() {
+        let p = plan([
+            "hook_event_name": "Stop",
+            "last_assistant_message": "Would you like me to continue?",
+            "cwd": "/tmp",
+        ])
+        let body = buildStopPayload(p)
+        XCTAssertEqual(body["title"] as? String, "Waiting")
+        XCTAssertEqual(body["style"] as? String, "reminder")
+    }
+
+    func testStop_declarativeMessage_emitsDone() {
+        let p = plan([
+            "hook_event_name": "Stop",
+            "last_assistant_message": "All done.",
+            "cwd": "/tmp",
+        ])
+        let body = buildStopPayload(p)
+        XCTAssertEqual(body["title"] as? String, "Done")
+        XCTAssertEqual(body["style"] as? String, "success")
+    }
+
+    func testStop_fullwidthQuestionMark() {
+        let p = plan([
+            "hook_event_name": "Stop",
+            "last_assistant_message": "要繼續嗎？",
+            "cwd": "/tmp",
+        ])
+        XCTAssertEqual(buildStopPayload(p)["title"] as? String, "Waiting")
+    }
+
+    // MARK: - PermissionRequest with FIFO cache
+
+    func testPermissionRequest_EnrichesWithCachedDiff() {
+        let p = plan([
+            "hook_event_name": "PermissionRequest", "tool_name": "Edit",
+            "tool_input": ["file_path": "/tmp/x.swift"],
+            "cwd": "/tmp",
+        ])
+        let cached: [String: Any] = [
+            "old_string": "let x = 1",
+            "new_string": "let x = 42",
+        ]
+        let body = buildPermissionRequestPayload(p, cachedInput: cached, cachedToolName: "Edit")
+        XCTAssertEqual(body["title"] as? String, "Permission")
+        XCTAssertEqual(body["detail"] as? String, "- let x = 1\n+ let x = 42")
+        XCTAssertEqual(body["style"] as? String, "action")
+    }
+
+    func testPermissionRequest_NoCachedInput_stillBuildsWithoutDetail() {
+        let p = plan([
+            "hook_event_name": "PermissionRequest", "tool_name": "Edit",
+            "tool_input": ["file_path": "/tmp/x.swift"],
+            "cwd": "/tmp",
+        ])
+        let body = buildPermissionRequestPayload(p, cachedInput: nil, cachedToolName: nil)
+        XCTAssertEqual(body["title"] as? String, "Permission")
+        XCTAssertNil(body["detail"])
+    }
+
+    func testPermissionRequest_CachedToolMismatch_ignored() {
+        let p = plan([
+            "hook_event_name": "PermissionRequest", "tool_name": "Edit",
+            "tool_input": ["file_path": "/tmp/x"],
+            "cwd": "/tmp",
+        ])
+        // cached name differs from current tool → do not enrich
+        let body = buildPermissionRequestPayload(
+            p,
+            cachedInput: ["old_string": "a", "new_string": "b"],
+            cachedToolName: "Bash"
+        )
+        XCTAssertNil(body["detail"])
+    }
+
+    // MARK: - Session lifecycle
+
+    func testSessionStart_usesSourceField() {
+        let p = plan([
+            "hook_event_name": "SessionStart", "source": "resume", "cwd": "/tmp",
+        ])
+        let body = buildSessionStartPayload(p)
+        XCTAssertEqual(body["title"] as? String, "Session")
+        XCTAssertEqual(body["subtitle"] as? String, "resume")
+    }
+
+    func testPreCompactAndPostCompact() {
+        let p = plan(["hook_event_name": "PreCompact", "cwd": "/tmp"])
+        XCTAssertEqual(buildPreCompactPayload(p)["title"] as? String, "Compacting")
+        XCTAssertEqual(buildPostCompactPayload(p)["title"] as? String, "Compacted")
+    }
+}


### PR DESCRIPTION
## Summary
The hook binary's pure logic (~400 lines previously at file scope in \`main.swift\`) now lives in a separate SPM library target, \`IslandHookCore\`, so it can be unit-tested in isolation. \`main.swift\` shrinks to ~120 lines of I/O — read stdin, dispatch via the library, send / long-poll over the local socket.

## New layout
\`\`\`
Sources/IslandHookCore/
  Format.swift          truncate, basename, diffLines, buildEditDiff
  HookPlan.swift        parseHookPlan + extension methods (decorate, filePath, command, ...)
  PayloadBuilder.swift  build*Payload per event type

Sources/island-hook/
  main.swift            slim CLI shell — imports IslandHookCore

Tests/IslandHookCoreTests/
  FormatTests.swift           17 tests
  HookPlanTests.swift         15 tests
  PayloadBuilderTests.swift   26 tests
\`\`\`

## Coverage highlights
- truncate / basename / diffLines / buildEditDiff edge cases (empty, exact-max, multi-line truncation, "(+N more)" appendage)
- Source detection: PascalCase = Claude, camelCase = Copilot, env override = Codex, legacy \`toolName\`-at-root = Copilot, unroutable returns nil
- Copilot event normalization (all 6 mappings) + tool-name normalization
- Subagent label override (\`↳ agent_type\`)
- Per-tool PreToolUse payloads (Edit with diff, Write with content preview, Bash with description fallback, Grep, Agent, MCP prefix stripping)
- PostToolUse only emits for Edit/Write
- StopFailure / PermissionDenied / Notification (skipping permission_prompt)
- Stop's question detection (English \`?\` + fullwidth \`？\`)
- PermissionRequest FIFO enrichment (with cached input, without, mismatched tool)

All 58 tests pass in <20ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)