### PR TITLE
Show Claude's actual question on Stop event

### DIFF
--- a/Sources/IslandHookCore/PayloadBuilder.swift
+++ b/Sources/IslandHookCore/PayloadBuilder.swift
@@ -186,14 +186,50 @@ public func buildStopPayload(_ plan: HookPlan) -> [String: Any] {
     let lastMsg = (plan.payload["last_assistant_message"] as? String) ?? ""
     let tail = String(lastMsg.suffix(200))
     if tail.range(of: #"[?？]\s*$"#, options: .regularExpression) != nil {
-        return plan.decorate([
-            "title": "Waiting", "subtitle": "Your turn", "style": "reminder",
-        ])
+        let question = extractLastQuestion(from: lastMsg)
+        var p: [String: Any] = [
+            "title": "Waiting",
+            "subtitle": truncate(question.isEmpty ? "Your turn" : question, 50),
+            "style": "reminder",
+        ]
+        if !lastMsg.isEmpty { p["detail"] = lastMsg }
+        return plan.decorate(p)
     } else {
         return plan.decorate([
             "title": "Done", "style": "success", "duration": 3,
         ])
     }
+}
+
+/// Pulls the final sentence from an assistant message — typically the question
+/// Claude is asking. Splits at sentence terminators (`.`, `!`, `?`, fullwidth
+/// `。`, `！`, `？`) and newlines so a multi-sentence single-line message gets
+/// the trailing sentence isolated rather than the whole message.
+public func extractLastQuestion(from text: String) -> String {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty { return "" }
+
+    let terminators: Set<Character> = [".", "!", "?", "。", "！", "？", "\n"]
+
+    // Skip the trailing terminator so the reverse walk doesn't treat it as
+    // the sentence separator (we want the PRIOR one).
+    var idx = trimmed.endIndex
+    if let lastChar = trimmed.last, terminators.contains(lastChar) {
+        idx = trimmed.index(before: idx)
+    }
+
+    while idx > trimmed.startIndex {
+        let prev = trimmed.index(before: idx)
+        if terminators.contains(trimmed[prev]) {
+            var startIdx = idx
+            while startIdx < trimmed.endIndex && trimmed[startIdx].isWhitespace {
+                startIdx = trimmed.index(after: startIdx)
+            }
+            return String(trimmed[startIdx...]).trimmingCharacters(in: .whitespaces)
+        }
+        idx = prev
+    }
+    return trimmed
 }
 
 public func buildStopFailurePayload(_ plan: HookPlan) -> [String: Any] {

--- a/Tests/IslandHookCoreTests/PayloadBuilderTests.swift
+++ b/Tests/IslandHookCoreTests/PayloadBuilderTests.swift
@@ -215,7 +215,7 @@ final class PayloadBuilderTests: XCTestCase {
 
     // MARK: - Stop (asking-question detection)
 
-    func testStop_questionMark_emitsWaiting() {
+    func testStop_questionMark_emitsWaitingWithQuestion() {
         let p = plan([
             "hook_event_name": "Stop",
             "last_assistant_message": "Would you like me to continue?",
@@ -223,7 +223,89 @@ final class PayloadBuilderTests: XCTestCase {
         ])
         let body = buildStopPayload(p)
         XCTAssertEqual(body["title"] as? String, "Waiting")
+        XCTAssertEqual(body["subtitle"] as? String, "Would you like me to continue?")
         XCTAssertEqual(body["style"] as? String, "reminder")
+        XCTAssertEqual(body["detail"] as? String, "Would you like me to continue?")
+    }
+
+    func testStop_multilineMessage_subtitleIsLastLine() {
+        let msg = "I've made the changes to foo.swift.\n\nShould I run the tests?"
+        let p = plan([
+            "hook_event_name": "Stop",
+            "last_assistant_message": msg,
+            "cwd": "/tmp",
+        ])
+        let body = buildStopPayload(p)
+        XCTAssertEqual(body["subtitle"] as? String, "Should I run the tests?")
+        XCTAssertEqual(body["detail"] as? String, msg)
+    }
+
+    func testStop_listFollowedByQuestion_takesLastLine() {
+        let msg = "Done with all 5 changes:\n- a\n- b\n- c\nWant me to commit?"
+        let p = plan([
+            "hook_event_name": "Stop",
+            "last_assistant_message": msg,
+            "cwd": "/tmp",
+        ])
+        XCTAssertEqual(buildStopPayload(p)["subtitle"] as? String, "Want me to commit?")
+    }
+
+    func testStop_longQuestion_truncatedTo50() {
+        // A single sentence with no internal punctuation — exercises the
+        // 50-char clip after sentence extraction.
+        let msg = String(repeating: "very ", count: 30)
+            + "long question with no internal punctuation?"
+        let p = plan([
+            "hook_event_name": "Stop",
+            "last_assistant_message": msg,
+            "cwd": "/tmp",
+        ])
+        let sub = buildStopPayload(p)["subtitle"] as? String ?? ""
+        XCTAssertLessThanOrEqual(sub.count, 51)
+        XCTAssertTrue(sub.hasSuffix("…"))
+    }
+
+    func testExtractLastQuestion_singleLine() {
+        XCTAssertEqual(extractLastQuestion(from: "Hello?"), "Hello?")
+    }
+
+    func testExtractLastQuestion_multilineLastNonEmpty() {
+        XCTAssertEqual(
+            extractLastQuestion(from: "First\n\nLast?"),
+            "Last?"
+        )
+    }
+
+    func testExtractLastQuestion_trailingWhitespace() {
+        XCTAssertEqual(
+            extractLastQuestion(from: "Question?  \n\n  "),
+            "Question?"
+        )
+    }
+
+    func testExtractLastQuestion_empty() {
+        XCTAssertEqual(extractLastQuestion(from: ""), "")
+    }
+
+    func testExtractLastQuestion_chinesePeriodAsSeparator() {
+        XCTAssertEqual(
+            extractLastQuestion(from: "送出去了。看起來怎樣？"),
+            "看起來怎樣？"
+        )
+    }
+
+    func testExtractLastQuestion_englishPeriodSeparator() {
+        XCTAssertEqual(
+            extractLastQuestion(from: "First sentence. Second one?"),
+            "Second one?"
+        )
+    }
+
+    func testExtractLastQuestion_mixedPunctuation_takesAfterLastTerminator() {
+        XCTAssertEqual(
+            extractLastQuestion(from: "Made the change! Want to commit?"),
+            "Want to commit?"
+        )
     }
 
     func testStop_declarativeMessage_emitsDone() {


### PR DESCRIPTION
## Summary
\`Stop\` events used to show a generic \`Waiting / Your turn\`. Now the subtitle is the actual final sentence of Claude's message, so the user sees what's being asked at a glance.

## How it works
\`extractLastQuestion\` walks the trimmed message backwards from the (skipped) trailing terminator, looking for the previous sentence break (\`.\`, \`!\`, \`?\`, fullwidth \`。\`, \`！\`, \`？\`, or \`\\n\`). Returns whatever comes after, trimmed. If there's no internal terminator, returns the whole thing.

The full message is also dropped into the event's \`detail\` so the expanded island view has the full context.

## Behaviour examples
| Input | Subtitle |
|---|---|
| \`"Continue?"\` | \`Continue?\` |
| \`"Made the change. Want to commit?"\` | \`Want to commit?\` |
| \`"Done with all 5:\\n- a\\n- b\\nReady?"\` | \`Ready?\` |
| \`"送出去了。看起來怎樣？"\` | \`看起來怎樣？\` |

Long single sentences with no internal punctuation still get truncated to 50 chars + ellipsis to stay readable in the ear.

## Test plan
- [ ] All 68 IslandHookCoreTests pass (\`swift test\`)
- [ ] Trigger a Stop event with a question — island shows the question text on the right ear, "Waiting" on the left
- [ ] Expand the island — full message visible in detail
- [ ] Trigger a Stop with no question — still shows "Done"

🤖 Generated with [Claude Code](https://claude.com/claude-code)