### PR TITLE
Run swift test in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Check Swift version
         run: swift --version
 
+      - name: Run tests
+        run: swift test
+
       - name: Build release
         run: swift build -c release
 


### PR DESCRIPTION
## Summary
Adds a \`swift test\` step to the GitHub Action workflow before the release build, so any IslandHookCore regression breaks the PR check instead of slipping into main.

The 68 unit tests run in <20ms, so the CI cost is negligible.

## Test plan
- [ ] Push triggers workflow with the new step
- [ ] Step appears as "Run tests" in the Actions log

🤖 Generated with [Claude Code](https://claude.com/claude-code)