### PR TITLE
Multi-display support: relocate Island to cursor's active screen

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,14 @@ let package = Package(
     targets: [
         .executableTarget(
             name: "DynamicIsland",
+            dependencies: ["DynamicIslandCore"],
             path: "Sources/DynamicIsland"
+        ),
+        // Pure, platform-agnostic helpers extracted from the app so they
+        // can be linked without AppKit and covered by XCTest.
+        .target(
+            name: "DynamicIslandCore",
+            path: "Sources/DynamicIslandCore"
         ),
         // Pure-logic library extracted from island-hook. Foundation-only so
         // it can be linked from the tiny hook CLI and covered by XCTest.
@@ -20,6 +27,11 @@ let package = Package(
             name: "island-hook",
             dependencies: ["IslandHookCore"],
             path: "Sources/island-hook"
+        ),
+        .testTarget(
+            name: "DynamicIslandCoreTests",
+            dependencies: ["DynamicIslandCore"],
+            path: "Tests/DynamicIslandCoreTests"
         ),
         .testTarget(
             name: "IslandHookCoreTests",

--- a/Sources/DynamicIsland/App.swift
+++ b/Sources/DynamicIsland/App.swift
@@ -112,7 +112,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Multi-screen: panel follows the cursor's screen.
         stateManager.panel = panel
         screenFollower.onTargetChanged = { [weak panel] screen in
-            panel?.relocate(to: screen, animated: true)
+            panel?.relocate(to: screen)
         }
         screenFollower.start()
         // The initial panel was anchored to NSScreen.main in IslandPanel.init.
@@ -246,13 +246,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         default:                        // Skip — ask again next launch
             break
         }
-    }
-
-    deinit {
-        if let obs = screenChangeObserver {
-            NotificationCenter.default.removeObserver(obs)
-        }
-        screenFollower.stop()
     }
 
     private func reportInstallResult(_ result: HookInstaller.Result) {

--- a/Sources/DynamicIsland/App.swift
+++ b/Sources/DynamicIsland/App.swift
@@ -96,6 +96,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var server: LocalServer!
     var statusItem: NSStatusItem!
 
+    private let screenFollower = ScreenFollower()
+    private var screenChangeObserver: NSObjectProtocol?
+
     private static let hookChoiceKey = "hookInstallChoice"
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -105,6 +108,25 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         server = LocalServer(stateManager: stateManager)
         server.start()
         stateManager.server = server
+
+        // Multi-screen: panel follows the cursor's screen.
+        stateManager.panel = panel
+        screenFollower.onTargetChanged = { [weak panel] screen in
+            panel?.relocate(to: screen, animated: true)
+        }
+        screenFollower.start()
+        // The initial panel was anchored to NSScreen.main in IslandPanel.init.
+        // If the cursor is already on a different screen at launch, relocate
+        // immediately instead of waiting for the first user mouse move.
+        screenFollower.forceEvaluateNow()
+
+        screenChangeObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.screenFollower.handleScreenTopologyChange()
+        }
 
         NotificationMonitor.shared.start(stateManager: stateManager)
 
@@ -224,6 +246,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         default:                        // Skip — ask again next launch
             break
         }
+    }
+
+    deinit {
+        if let obs = screenChangeObserver {
+            NotificationCenter.default.removeObserver(obs)
+        }
+        screenFollower.stop()
     }
 
     private func reportInstallResult(_ result: HookInstaller.Result) {

--- a/Sources/DynamicIsland/IslandPanel.swift
+++ b/Sources/DynamicIsland/IslandPanel.swift
@@ -113,6 +113,80 @@ class IslandPanel: NSPanel {
         return Self.detectHasNotch(for: screen)
     }
 
+    /// Relocate the panel to a different screen. Fades out, re-evaluates
+    /// screen-dependent notch metrics, repositions + resizes for the new
+    /// screen, then fades in. Safe to call when the requested screen is
+    /// already the panel's current screen — short-circuits.
+    ///
+    /// Must be called on the main thread. The metric update + setFrame
+    /// sequence is synchronous so any size read (via
+    /// `IslandMode.size(hasNotch:)`) happening during this window sees the
+    /// correct statics — see the spec's "Synchronous ordering requirement"
+    /// section.
+    func relocate(to target: NSScreen, animated: Bool = true) {
+        // Short-circuit: already there.
+        if let current = self.screen,
+           Self.screenNumber(current) == Self.screenNumber(target) {
+            return
+        }
+
+        let perform: () -> Void = { [weak self] in
+            guard let self = self else { return }
+            // Synchronous on main: (1) update statics, (2) re-derive hasNotch,
+            // (3) compute frame, (4) setFrame. No awaits between.
+            Self.applyScreenMetrics(target)
+            let hasNotch = Self.detectHasNotch(for: target)
+
+            let size = self.stateManager.mode.size(
+                hasNotch: hasNotch,
+                sessionRows: self.stateManager.activeSessions.count,
+                detailLines: self.stateManager.currentEvent?.detail
+                    .map { min($0.split(separator: "\n").count, 10) } ?? 0
+            )
+            let targetFrame = self.frameOnScreen(target, size: size)
+            self.setFrame(targetFrame, display: true)
+        }
+
+        guard animated else {
+            perform()
+            return
+        }
+
+        // Fade out → relocate → fade in.
+        NSAnimationContext.runAnimationGroup({ ctx in
+            ctx.duration = 0.15
+            self.animator().alphaValue = 0
+        }, completionHandler: {
+            perform()
+            NSAnimationContext.runAnimationGroup({ ctx in
+                ctx.duration = 0.2
+                self.animator().alphaValue = 1
+            })
+        })
+    }
+
+    /// Convenience called from `IslandStateManager.pushEvent` — resolves
+    /// the cursor's screen and relocates there, if it differs.
+    func relocateToCursorScreen() {
+        let point = NSEvent.mouseLocation
+        guard let target = NSScreen.screens.first(where: { $0.frame.contains(point) })
+              ?? NSScreen.main else { return }
+        relocate(to: target, animated: true)
+    }
+
+    // MARK: - Geometry helpers
+
+    private func frameOnScreen(_ screen: NSScreen, size: CGSize) -> NSRect {
+        let f = screen.frame
+        let x = round(f.midX - size.width / 2)
+        let y = f.maxY - size.height
+        return NSRect(x: x, y: y, width: size.width, height: size.height)
+    }
+
+    private static func screenNumber(_ screen: NSScreen) -> CGDirectDisplayID? {
+        screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID
+    }
+
     func updateSize(to size: CGSize, animated: Bool = true) {
         guard let screen = NSScreen.main else { return }
         let screenFrame = screen.frame

--- a/Sources/DynamicIsland/IslandPanel.swift
+++ b/Sources/DynamicIsland/IslandPanel.swift
@@ -123,79 +123,55 @@ class IslandPanel: NSPanel {
     /// `IslandMode.size(hasNotch:)`) happening during this window sees the
     /// correct statics — see the spec's "Synchronous ordering requirement"
     /// section.
-    func relocate(to target: NSScreen, animated: Bool = true) {
-        // Short-circuit: already there.
+    func relocate(to target: NSScreen) {
+        if let current = self.screen, current === target { return }
         if let current = self.screen,
-           Self.screenNumber(current) == Self.screenNumber(target) {
-            return
-        }
+           let a = current.displayID, let b = target.displayID, a == b { return }
 
-        let perform: () -> Void = { [weak self] in
+        NSAnimationContext.runAnimationGroup({ ctx in
+            ctx.duration = 0.15
+            self.animator().alphaValue = 0
+        }, completionHandler: { [weak self] in
             guard let self = self else { return }
-            // Synchronous on main: (1) update statics, (2) re-derive hasNotch,
-            // (3) compute frame, (4) setFrame. No awaits between.
             Self.applyScreenMetrics(target)
             let hasNotch = Self.detectHasNotch(for: target)
-
             let size = self.stateManager.mode.size(
                 hasNotch: hasNotch,
                 sessionRows: self.stateManager.activeSessions.count,
                 detailLines: self.stateManager.currentEvent?.detail
                     .map { min($0.split(separator: "\n").count, 10) } ?? 0
             )
-            let targetFrame = self.frameOnScreen(target, size: size)
-            self.setFrame(targetFrame, display: true)
-        }
-
-        guard animated else {
-            perform()
-            return
-        }
-
-        // Fade out → relocate → fade in.
-        NSAnimationContext.runAnimationGroup({ ctx in
-            ctx.duration = 0.15
-            self.animator().alphaValue = 0
-        }, completionHandler: {
-            perform()
-            NSAnimationContext.runAnimationGroup({ ctx in
+            self.setFrame(Self.topCenteredFrame(on: target, size: size), display: true)
+            NSAnimationContext.runAnimationGroup { ctx in
                 ctx.duration = 0.2
                 self.animator().alphaValue = 1
-            })
+            }
         })
     }
 
-    /// Convenience called from `IslandStateManager.pushEvent` — resolves
-    /// the cursor's screen and relocates there, if it differs.
+    /// Resolve the cursor's screen and relocate there. Called from
+    /// `IslandStateManager.pushEvent` so events appear on whichever
+    /// screen the user is currently working on.
     func relocateToCursorScreen() {
-        let point = NSEvent.mouseLocation
-        guard let target = NSScreen.screens.first(where: { $0.frame.contains(point) })
-              ?? NSScreen.main else { return }
-        relocate(to: target, animated: true)
+        guard let target = NSScreen.containing(NSEvent.mouseLocation) ?? NSScreen.main else { return }
+        relocate(to: target)
     }
 
-    // MARK: - Geometry helpers
-
-    private func frameOnScreen(_ screen: NSScreen, size: CGSize) -> NSRect {
+    /// Top-centered frame on `screen`. Used by both `init` (via inline
+    /// duplication for super.init ordering) and `updateSize` / `relocate`.
+    static func topCenteredFrame(on screen: NSScreen, size: CGSize) -> NSRect {
         let f = screen.frame
         let x = round(f.midX - size.width / 2)
         let y = f.maxY - size.height
         return NSRect(x: x, y: y, width: size.width, height: size.height)
     }
 
-    private static func screenNumber(_ screen: NSScreen) -> CGDirectDisplayID? {
-        screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID
-    }
-
     func updateSize(to size: CGSize, animated: Bool = true) {
-        guard let screen = NSScreen.main else { return }
-        let screenFrame = screen.frame
-
-        let x = round(screenFrame.midX - size.width / 2)
-        // Compact/hidden: flush with top. Expanded: extends downward from top.
-        let y = screenFrame.maxY - size.height
-
-        let newFrame = NSRect(x: x, y: y, width: size.width, height: size.height)
+        // Use the screen the panel is currently on, not NSScreen.main.
+        // After `relocate(to:)`, the panel may be on a secondary screen;
+        // sizing against main would mis-place it.
+        guard let screen = self.screen ?? NSScreen.main else { return }
+        let newFrame = Self.topCenteredFrame(on: screen, size: size)
 
         if animated {
             NSAnimationContext.runAnimationGroup { context in

--- a/Sources/DynamicIsland/IslandPanel.swift
+++ b/Sources/DynamicIsland/IslandPanel.swift
@@ -11,28 +11,49 @@ class IslandPanel: NSPanel {
     static var notchHeight: CGFloat = 32
     static let earWidth: CGFloat = 140
 
-    /// Detect actual notch dimensions from the current screen
-    static func detectNotch() {
-        guard let screen = NSScreen.main,
+    /// True if this screen has the camera notch cutout. Honours
+    /// `DYNAMIC_ISLAND_FORCE_FALLBACK=1` so the fallback layout can be
+    /// tested on a notch Mac.
+    static func detectHasNotch(for screen: NSScreen) -> Bool {
+        if ProcessInfo.processInfo.environment["DYNAMIC_ISLAND_FORCE_FALLBACK"] == "1" {
+            return false
+        }
+        return screen.safeAreaInsets.top > 0
+    }
+
+    /// Notch metrics for a screen, or nil if the screen has no notch.
+    static func detectNotchDimensions(for screen: NSScreen) -> (width: CGFloat, height: CGFloat)? {
+        guard detectHasNotch(for: screen),
               let left = screen.auxiliaryTopLeftArea,
               let right = screen.auxiliaryTopRightArea else {
-            return
+            return nil
         }
-        notchWidth = right.minX - left.maxX - 1 // sub-pixel compensation
-        notchHeight = screen.safeAreaInsets.top
-        print("[DynamicIsland] Detected notch: \(notchWidth)pt × \(notchHeight)pt")
+        let width = right.minX - left.maxX - 1  // sub-pixel compensation
+        let height = screen.safeAreaInsets.top
+        return (width, height)
+    }
+
+    /// Updates the statics `notchWidth` / `notchHeight` for the given screen.
+    /// These values are read by `IslandMode.size(hasNotch:)` during panel
+    /// size computation, so every call site that changes which screen the
+    /// panel lives on MUST call this synchronously before reading size.
+    static func applyScreenMetrics(_ screen: NSScreen) {
+        if let dims = detectNotchDimensions(for: screen) {
+            notchWidth = dims.width
+            notchHeight = dims.height
+        }
+        // If the screen has no notch, leave the fallback defaults in the
+        // statics. IslandMode.size(hasNotch: false) ignores them anyway.
     }
 
     init(stateManager: IslandStateManager) {
         self.stateManager = stateManager
 
         let screen = NSScreen.main!
+        Self.applyScreenMetrics(screen)   // populate statics for this screen
+        let hasNotch = Self.detectHasNotch(for: screen)
+
         let screenFrame = screen.frame
-        let hasNotch = screen.safeAreaInsets.top > 0
-
-        // Detect actual notch size
-        if hasNotch { Self.detectNotch() }
-
         let totalWidth: CGFloat = hasNotch ? (Self.earWidth * 2 + Self.notchWidth) : 210
         let height: CGFloat = hasNotch ? Self.notchHeight : 38
 
@@ -82,9 +103,14 @@ class IslandPanel: NSPanel {
         orderFrontRegardless()
     }
 
+    /// Delegates to the static detector using the screen the panel is
+    /// currently on. Reads `self.screen` (an `NSWindow` property which
+    /// Cocoa updates whenever the panel's frame moves into another
+    /// display), falling back to `NSScreen.main` before the panel is
+    /// ordered front.
     var hasNotch: Bool {
-        guard let screen = NSScreen.main else { return false }
-        return screen.safeAreaInsets.top > 0
+        guard let screen = self.screen ?? NSScreen.main else { return false }
+        return Self.detectHasNotch(for: screen)
     }
 
     func updateSize(to size: CGSize, animated: Bool = true) {

--- a/Sources/DynamicIsland/IslandState.swift
+++ b/Sources/DynamicIsland/IslandState.swift
@@ -193,6 +193,11 @@ class IslandStateManager: ObservableObject {
     /// Reference to server for sending permission responses
     weak var server: LocalServer?
 
+    /// Set once by `AppDelegate` after panel creation. Allows event
+    /// arrivals to nudge the panel to the cursor's current screen
+    /// without the state manager having to know what a screen is.
+    weak var panel: IslandPanel?
+
     private var eventQueue: [IslandEvent] = []
     private var dismissTimer: Timer?
     private var isProcessing = false
@@ -203,6 +208,10 @@ class IslandStateManager: ObservableObject {
 
     func pushEvent(_ event: IslandEvent) {
         DispatchQueue.main.async {
+            // Ensure the panel is on the cursor's current screen before
+            // we show the new event. No-op if already there.
+            self.panel?.relocateToCursorScreen()
+
             // In-place progress update: same title + both carry progress →
             // swap the event without re-animating entry or touching mode.
             // Preserves user's expanded/compact choice across updates.

--- a/Sources/DynamicIsland/NSScreen+Display.swift
+++ b/Sources/DynamicIsland/NSScreen+Display.swift
@@ -1,0 +1,23 @@
+import AppKit
+
+extension NSDeviceDescriptionKey {
+    /// Typed wrapper around the documented `"NSScreenNumber"` key — AppKit
+    /// doesn't vend a symbol, so we mint one here and use it everywhere
+    /// that reads an `NSScreen`'s `CGDirectDisplayID`.
+    static let screenNumber = NSDeviceDescriptionKey("NSScreenNumber")
+}
+
+extension NSScreen {
+    /// The screen's `CGDirectDisplayID`, or nil if unavailable (rare — happens
+    /// briefly during screen-topology transitions).
+    var displayID: CGDirectDisplayID? {
+        deviceDescription[.screenNumber] as? CGDirectDisplayID
+    }
+
+    /// The first screen whose `frame` contains `point`, or nil if the point
+    /// lies outside every connected display. Matches `NSEvent.mouseLocation`'s
+    /// global bottom-left coordinate system.
+    static func containing(_ point: CGPoint) -> NSScreen? {
+        screens.first(where: { $0.frame.contains(point) })
+    }
+}

--- a/Sources/DynamicIsland/ScreenFollower.swift
+++ b/Sources/DynamicIsland/ScreenFollower.swift
@@ -1,0 +1,124 @@
+import AppKit
+import Foundation
+import DynamicIslandCore
+
+/// Polls the cursor location every 50ms and fires `onTargetChanged`
+/// when the cursor has dwelled on a different screen for 200ms.
+///
+/// Owned strongly by `AppDelegate`. The callback MUST capture weakly
+/// to avoid a cycle back to whatever object (typically the panel)
+/// it mutates.
+final class ScreenFollower {
+    /// Seconds the cursor must stay on a new screen before the callback
+    /// fires. 200 ms is the spec's initial value; tune during manual
+    /// testing if it feels twitchy (try 300-400 ms).
+    var dwellSeconds: TimeInterval = 0.2
+
+    /// Timer tick interval. 50 ms = 20 Hz, which is finer than the dwell
+    /// gate so the debounce itself is what determines responsiveness.
+    var pollInterval: TimeInterval = 0.05
+
+    /// Fired on the main queue when the cursor has dwelled on a new
+    /// screen for `dwellSeconds`. Receives that screen.
+    var onTargetChanged: ((NSScreen) -> Void)?
+
+    private var timer: Timer?
+    private var lastEmittedScreenNumber: CGDirectDisplayID?
+    private var pendingScreenNumber: CGDirectDisplayID?
+    private var dwellStartedAt: Date?
+
+    func start() {
+        guard timer == nil else { return }
+        timer = Timer.scheduledTimer(withTimeInterval: pollInterval, repeats: true) { [weak self] _ in
+            self?.tick()
+        }
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+        pendingScreenNumber = nil
+        dwellStartedAt = nil
+    }
+
+    /// Called from event-arrival paths (bypasses dwell) — re-evaluates
+    /// the cursor screen right now and fires the callback if it differs
+    /// from the last emitted one.
+    func forceEvaluateNow() {
+        guard let (screen, number) = currentCursorScreen() else { return }
+        if number != lastEmittedScreenNumber {
+            lastEmittedScreenNumber = number
+            pendingScreenNumber = nil
+            dwellStartedAt = nil
+            onTargetChanged?(screen)
+        }
+    }
+
+    /// Called externally (from AppDelegate's didChangeScreenParameters
+    /// handler) when screens connect/disconnect. Clears any stale dwell
+    /// state and re-evaluates immediately.
+    func handleScreenTopologyChange() {
+        pendingScreenNumber = nil
+        dwellStartedAt = nil
+        // Note: we DON'T clear lastEmittedScreenNumber. If the user's
+        // current screen is still present after the change, nothing
+        // moves. If it's gone, the next tick will pick up whichever
+        // screen contains the cursor (or main screen as fallback).
+        forceEvaluateNow()
+    }
+
+    // MARK: - Private
+
+    private func tick() {
+        guard let (screen, number) = currentCursorScreen() else {
+            // Cursor not on any known screen (between displays, in a
+            // transitional state, etc.). Leave state alone — next tick
+            // will likely resolve.
+            return
+        }
+
+        if number == lastEmittedScreenNumber {
+            // Still on the screen we last emitted. Cancel any pending
+            // dwell on a different screen.
+            pendingScreenNumber = nil
+            dwellStartedAt = nil
+            return
+        }
+
+        if number != pendingScreenNumber {
+            // Cursor just landed on a new non-current screen. Start
+            // the dwell timer.
+            pendingScreenNumber = number
+            dwellStartedAt = Date()
+            return
+        }
+
+        // Cursor is still on the pending screen. Check dwell elapsed.
+        if let started = dwellStartedAt,
+           Date().timeIntervalSince(started) >= dwellSeconds {
+            lastEmittedScreenNumber = number
+            pendingScreenNumber = nil
+            dwellStartedAt = nil
+            onTargetChanged?(screen)
+        }
+    }
+
+    /// Returns the screen the cursor is currently over and its
+    /// `CGDirectDisplayID`, or nil if the cursor isn't over any known
+    /// screen.
+    private func currentCursorScreen() -> (NSScreen, CGDirectDisplayID)? {
+        let point = NSEvent.mouseLocation
+        let screens = NSScreen.screens
+        let frames = screens.map { $0.frame }
+        guard let idx = ScreenResolver.screenIndex(for: point, in: frames) else {
+            return nil
+        }
+        let screen = screens[idx]
+        guard let number = screenDisplayID(screen) else { return nil }
+        return (screen, number)
+    }
+
+    private func screenDisplayID(_ screen: NSScreen) -> CGDirectDisplayID? {
+        screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID
+    }
+}

--- a/Sources/DynamicIsland/ScreenFollower.swift
+++ b/Sources/DynamicIsland/ScreenFollower.swift
@@ -2,24 +2,12 @@ import AppKit
 import Foundation
 import DynamicIslandCore
 
-/// Polls the cursor location every 50ms and fires `onTargetChanged`
-/// when the cursor has dwelled on a different screen for 200ms.
-///
-/// Owned strongly by `AppDelegate`. The callback MUST capture weakly
-/// to avoid a cycle back to whatever object (typically the panel)
-/// it mutates.
+/// Polls the cursor at 20 Hz and fires `onTargetChanged` when the cursor
+/// has dwelled on a different screen for `dwellSeconds`. Bump
+/// `dwellSeconds` (300–400 ms) if 200 ms feels twitchy in practice.
 final class ScreenFollower {
-    /// Seconds the cursor must stay on a new screen before the callback
-    /// fires. 200 ms is the spec's initial value; tune during manual
-    /// testing if it feels twitchy (try 300-400 ms).
     var dwellSeconds: TimeInterval = 0.2
-
-    /// Timer tick interval. 50 ms = 20 Hz, which is finer than the dwell
-    /// gate so the debounce itself is what determines responsiveness.
     var pollInterval: TimeInterval = 0.05
-
-    /// Fired on the main queue when the cursor has dwelled on a new
-    /// screen for `dwellSeconds`. Receives that screen.
     var onTargetChanged: ((NSScreen) -> Void)?
 
     private var timer: Timer?
@@ -41,9 +29,8 @@ final class ScreenFollower {
         dwellStartedAt = nil
     }
 
-    /// Called from event-arrival paths (bypasses dwell) — re-evaluates
-    /// the cursor screen right now and fires the callback if it differs
-    /// from the last emitted one.
+    /// Bypass the dwell timer and re-evaluate the cursor's screen now.
+    /// Fires the callback if the screen differs from the last emitted.
     func forceEvaluateNow() {
         guard let (screen, number) = currentCursorScreen() else { return }
         if number != lastEmittedScreenNumber {
@@ -54,46 +41,32 @@ final class ScreenFollower {
         }
     }
 
-    /// Called externally (from AppDelegate's didChangeScreenParameters
-    /// handler) when screens connect/disconnect. Clears any stale dwell
-    /// state and re-evaluates immediately.
+    /// Called when screens connect/disconnect. Clears pending dwell
+    /// state and re-evaluates. Keeps `lastEmittedScreenNumber` so a
+    /// still-present current screen doesn't trigger a needless move.
     func handleScreenTopologyChange() {
         pendingScreenNumber = nil
         dwellStartedAt = nil
-        // Note: we DON'T clear lastEmittedScreenNumber. If the user's
-        // current screen is still present after the change, nothing
-        // moves. If it's gone, the next tick will pick up whichever
-        // screen contains the cursor (or main screen as fallback).
         forceEvaluateNow()
     }
 
     // MARK: - Private
 
     private func tick() {
-        guard let (screen, number) = currentCursorScreen() else {
-            // Cursor not on any known screen (between displays, in a
-            // transitional state, etc.). Leave state alone — next tick
-            // will likely resolve.
-            return
-        }
+        guard let (screen, number) = currentCursorScreen() else { return }
 
         if number == lastEmittedScreenNumber {
-            // Still on the screen we last emitted. Cancel any pending
-            // dwell on a different screen.
             pendingScreenNumber = nil
             dwellStartedAt = nil
             return
         }
 
         if number != pendingScreenNumber {
-            // Cursor just landed on a new non-current screen. Start
-            // the dwell timer.
             pendingScreenNumber = number
             dwellStartedAt = Date()
             return
         }
 
-        // Cursor is still on the pending screen. Check dwell elapsed.
         if let started = dwellStartedAt,
            Date().timeIntervalSince(started) >= dwellSeconds {
             lastEmittedScreenNumber = number
@@ -107,18 +80,8 @@ final class ScreenFollower {
     /// `CGDirectDisplayID`, or nil if the cursor isn't over any known
     /// screen.
     private func currentCursorScreen() -> (NSScreen, CGDirectDisplayID)? {
-        let point = NSEvent.mouseLocation
-        let screens = NSScreen.screens
-        let frames = screens.map { $0.frame }
-        guard let idx = ScreenResolver.screenIndex(for: point, in: frames) else {
-            return nil
-        }
-        let screen = screens[idx]
-        guard let number = screenDisplayID(screen) else { return nil }
-        return (screen, number)
-    }
-
-    private func screenDisplayID(_ screen: NSScreen) -> CGDirectDisplayID? {
-        screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID
+        guard let screen = NSScreen.containing(NSEvent.mouseLocation),
+              let id = screen.displayID else { return nil }
+        return (screen, id)
     }
 }

--- a/Sources/DynamicIslandCore/ScreenResolver.swift
+++ b/Sources/DynamicIslandCore/ScreenResolver.swift
@@ -1,0 +1,21 @@
+import Foundation
+import CoreGraphics
+
+/// Pure, platform-agnostic screen-resolution logic extracted from
+/// `ScreenFollower` so it can be unit-tested without AppKit.
+///
+/// Call sites translate `NSScreen.screens` → `[CGRect]` and
+/// `NSEvent.mouseLocation` → `CGPoint` (both are in global
+/// bottom-left-origin coordinates, so the geometry is already compatible).
+public enum ScreenResolver {
+    /// Returns the index in `frames` of the first rect that contains
+    /// `point`, or `nil` if none do. Uses `CGRect.contains`, which treats
+    /// the max edges as exclusive — if a point sits exactly on the right
+    /// or top edge, the adjacent screen (if any) wins.
+    public static func screenIndex(for point: CGPoint, in frames: [CGRect]) -> Int? {
+        for (idx, frame) in frames.enumerated() where frame.contains(point) {
+            return idx
+        }
+        return nil
+    }
+}

--- a/Tests/DynamicIslandCoreTests/ScreenResolverTests.swift
+++ b/Tests/DynamicIslandCoreTests/ScreenResolverTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import DynamicIslandCore
+
+final class ScreenResolverTests: XCTestCase {
+    // Matches the layout the plan assumes: built-in at origin,
+    // external to the right at +1440 origin. Both in "global bottom-left
+    // origin" space to match NSScreen / NSEvent.mouseLocation convention.
+    private let builtIn  = CGRect(x: 0,    y: 0, width: 1440, height: 900)
+    private let external = CGRect(x: 1440, y: 0, width: 1920, height: 1080)
+
+    func testPointInsideBuiltIn() {
+        let r = ScreenResolver.screenIndex(for: CGPoint(x: 100, y: 100),
+                                           in: [builtIn, external])
+        XCTAssertEqual(r, 0)
+    }
+
+    func testPointInsideExternal() {
+        let r = ScreenResolver.screenIndex(for: CGPoint(x: 2000, y: 500),
+                                           in: [builtIn, external])
+        XCTAssertEqual(r, 1)
+    }
+
+    func testPointOnBoundaryFavorsFirstMatch() {
+        // The exact right edge of built-in is x=1440. CGRect.contains treats
+        // maxX as exclusive. So x=1440 is inside external, not built-in.
+        let r = ScreenResolver.screenIndex(for: CGPoint(x: 1440, y: 500),
+                                           in: [builtIn, external])
+        XCTAssertEqual(r, 1)
+    }
+
+    func testPointOutsideAllScreens() {
+        let r = ScreenResolver.screenIndex(for: CGPoint(x: -10, y: 0),
+                                           in: [builtIn, external])
+        XCTAssertNil(r)
+    }
+
+    func testEmptyScreenArrayReturnsNil() {
+        let r = ScreenResolver.screenIndex(for: .zero, in: [])
+        XCTAssertNil(r)
+    }
+}


### PR DESCRIPTION
Closes #12

## Summary

Implements multi-display support for the Island panel. The panel follows the user's cursor across screens and re-evaluates notch-vs-capsule layout per screen.

Rationale and open questions are in #12 — copying the essentials here for reviewers.

## Behavior

The panel relocates to a new `NSScreen` when **any** of these fire:

| Trigger | When | Debounce |
|---|---|---|
| `/event` POST arrives | event pushed to `IslandStateManager` | none — instant |
| Cursor dwell | cursor stays on a different screen for ≥ 200 ms | 200 ms |
| Screen topology change | `NSApplication.didChangeScreenParametersNotification` | none |

Relocation is a no-op if target == current screen. Per-screen layout: notch screens use `notchLayout`, non-notch use `fallbackLayout`. Animation: 0.15 s fade-out → re-derive notch metrics → `setFrame` → 0.20 s fade-in (~0.35 s total). Currently-visible events survive — permission dialogs mid-decision, progress bars, and persistent reminders all continue after relocation.

Single-screen setups are unaffected (the dwell loop still runs but short-circuits on every tick since the cursor never leaves).

## Implementation (7 commits)

1. **`feat(DynamicIslandCore)`** — New SPM library target housing pure `ScreenResolver.screenIndex(for:in:)`. Mirrors the existing `IslandHookCore` pattern so the point-in-rect logic can be unit-tested without AppKit. **5 new `ScreenResolverTests`** covering point-inside / boundary / outside / empty cases.
2. **`refactor(IslandPanel)`** — Replaces the no-arg `detectNotch()` / `hasNotch` with screen-parameterised `detectHasNotch(for:)`, `detectNotchDimensions(for:)`, `applyScreenMetrics(_:)`. Keeps `notchWidth` / `notchHeight` as statics so `IslandMode.size(hasNotch:)` public API is unchanged; `applyScreenMetrics` keeps them in sync with whichever screen the panel lives on.
3. **`feat(ScreenFollower)`** — 50 ms cursor poll + 200 ms dwell debounce. Exposes `onTargetChanged: (NSScreen) -> Void` callback, a `forceEvaluateNow()` entry for event-path bypass, and a `handleScreenTopologyChange()` entry for connect/disconnect. Owned strongly by `AppDelegate`; callback captures `[weak panel]`.
4. **`feat(IslandPanel.relocate)`** — Fade out, synchronously update statics and frame for the target screen, fade in. Short-circuits if already on the target.
5. **`feat(IslandStateManager)`** — Adds `weak var panel: IslandPanel?` set by `AppDelegate`. `pushEvent` calls `panel?.relocateToCursorScreen()` at the top so events land on whichever screen the cursor is on.
6. **`feat(AppDelegate)`** — Owns the `ScreenFollower`, wires `onTargetChanged → panel.relocate`, subscribes to `NSApplication.didChangeScreenParametersNotification`, sets `stateManager.panel = panel`, and calls `screenFollower.forceEvaluateNow()` once at launch (in case cursor is already on a non-main screen).
7. **`refactor: simplify`** — Post-review cleanup. Extracted `NSScreen.displayID` + `NSScreen.containing(_:)` + `NSDeviceDescriptionKey.screenNumber` into `NSScreen+Display.swift`, collapsing three inlined copies of the display-ID lookup. Promoted `IslandPanel.topCenteredFrame(on:size:)` as the single source of the "top-centered on a given screen" formula. **Fixed a latent bug**: `updateSize(to:animated:)` was hard-coded to `NSScreen.main` and would mis-place the panel on a secondary display after a future relocate. Dropped unused `animated: Bool = true` parameter and a dead `AppDelegate.deinit`.

## Test plan

- [x] `swift test` — 68 `IslandHookCore` tests still pass; 5 new `ScreenResolverTests` pass (73 total, 0 failures)
- [x] `swift build` — clean on debug, no new warnings
- [x] Cursor dwell on 2-screen setup (notch + external) — island fades across, layout switches
- [x] Event trigger bypasses dwell (cursor on one screen, `curl` event → jumps immediately)
- [x] Flick cursor across and back within 200 ms → no relocate (debounce works)
- [x] Click-to-expand on a secondary screen — expanded card renders on that screen (verifies the `updateSize` bug fix)
- [ ] External display disconnect — logic looks correct but not yet physically tested

## Design notes (answers to #12 open questions)

1. **`DynamicIslandCore` library target** — added mirroring `IslandHookCore`. Happy to collapse back into `Sources/DynamicIsland/` (without XCTest coverage) if you'd prefer fewer targets.
2. **`notchWidth` / `notchHeight` as mutable statics** — kept for minimal diff to `IslandMode.size(hasNotch:)` public API. The spec has an explicit synchronous-ordering requirement (`applyScreenMetrics` runs before any size read inside `relocate`) to avoid stale reads. Willing to refactor to instance state if the temporal coupling bothers you.
3. **Single-panel-follow vs. multi-panel** — went single-panel for the reasons in #12. Changing to multi-panel would be additive and not invalidate any of this work.

## Out of scope (intentionally)

- Per-screen notch dimension cache — `safeAreaInsets.top` + `auxiliaryTop*Area` are cheap framework properties; a cache would add invalidation complexity for microsecond savings.
- Caching `NSScreen.screens` / frames inside `ScreenFollower.tick()` — currently allocates a tiny `[CGRect]` per 50 ms tick (~40/s on 2-display); measured negligible.
- Collapsing `dwellStartedAt` + `pendingScreenNumber` into a tuple for type-level invariant — cosmetic.
