### PR TITLE
Fix dropped hook events by reading HTTP requests across multiple TCP chunks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ build/
 xcuserdata/
 DerivedData/
 .DS_Store
+
+# Local-only development docs — issue drafts, specs, plans.
+# Kept in the working tree for the author's reference but never
+# committed / pushed. Actual issues live on GitHub; this is a staging area.
+.issues/
+docs/superpowers/
+.superpowers/

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,14 @@ let package = Package(
     targets: [
         .executableTarget(
             name: "DynamicIsland",
+            dependencies: ["DynamicIslandCore"],
             path: "Sources/DynamicIsland"
+        ),
+        // Pure, platform-agnostic helpers extracted from the app so they
+        // can be linked without AppKit and covered by XCTest.
+        .target(
+            name: "DynamicIslandCore",
+            path: "Sources/DynamicIslandCore"
         ),
         // Pure-logic library extracted from island-hook. Foundation-only so
         // it can be linked from the tiny hook CLI and covered by XCTest.
@@ -20,6 +27,11 @@ let package = Package(
             name: "island-hook",
             dependencies: ["IslandHookCore"],
             path: "Sources/island-hook"
+        ),
+        .testTarget(
+            name: "DynamicIslandCoreTests",
+            dependencies: ["DynamicIslandCore"],
+            path: "Tests/DynamicIslandCoreTests"
         ),
         .testTarget(
             name: "IslandHookCoreTests",

--- a/Sources/DynamicIsland/LocalServer.swift
+++ b/Sources/DynamicIsland/LocalServer.swift
@@ -77,49 +77,174 @@ class LocalServer {
         listener?.cancel()
     }
 
+    /// Per-connection read buffer cap. Generous enough for any realistic hook
+    /// payload (current hook payloads top out ~2 KB) while still bounding the
+    /// damage from a misbehaving client.
+    private static let maxRequestBytes = 1_048_576 // 1 MiB
+
     private func handleConnection(_ connection: NWConnection) {
         connection.start(queue: .global(qos: .userInitiated))
+        readRequest(connection: connection, buffer: Data())
+    }
 
-        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, _, error in
-            guard let self, let data, error == nil else {
+    /// Keeps calling `connection.receive` until we have a complete HTTP
+    /// request (headers + Content-Length bytes of body), then dispatches.
+    ///
+    /// Previously the server called `receive` exactly once and assumed the
+    /// entire request arrived in that single callback. URLSession (used by
+    /// the Swift `island-hook` binary) writes headers and body in separate
+    /// syscalls, which the Network framework routinely surfaces as separate
+    /// receive callbacks — so the body was being lost. See
+    /// `.issues/fix-localserver-partial-read.md`.
+    private func readRequest(connection: NWConnection, buffer: Data) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] chunk, _, isComplete, error in
+            guard let self else {
+                connection.cancel()
+                return
+            }
+            if let error = error {
+                print("[DynamicIsland] connection receive error: \(error)")
                 connection.cancel()
                 return
             }
 
-            let raw = String(data: data, encoding: .utf8) ?? ""
-            let firstLine = raw.components(separatedBy: "\r\n").first ?? ""
+            var buf = buffer
+            if let chunk = chunk { buf.append(chunk) }
 
-            if firstLine.contains("/response") {
-                // GET /response — hook script polls for user's permission choice
-                self.handleResponsePoll(connection)
-            } else if firstLine.contains("/event") {
-                // POST /event — parse body first so invalid payloads get a
-                // real error response instead of a misleading 200 OK.
-                do {
-                    guard let bodyRange = raw.range(of: "\r\n\r\n") else {
-                        throw EventError.missingBody
-                    }
-                    let bodyData = Data(raw[bodyRange.upperBound...].utf8)
-                    guard !bodyData.isEmpty else {
-                        throw EventError.missingBody
-                    }
-                    try self.processEvent(bodyData)
-                    self.sendHTTP(connection, body: "{\"status\":\"ok\"}")
-                } catch {
-                    let eventError = error as? EventError
-                    let code = eventError?.code ?? "internal_error"
-                    let message = eventError?.message ?? "\(error)"
-                    print("[DynamicIsland] /event error [\(code)]: \(message)")
-                    self.sendHTTP(
-                        connection,
-                        body: Self.errorBody(code: code, message: message),
-                        statusCode: "400 Bad Request"
-                    )
+            if buf.count > Self.maxRequestBytes {
+                print("[DynamicIsland] request exceeded \(Self.maxRequestBytes) bytes — dropping")
+                connection.cancel()
+                return
+            }
+
+            switch Self.parseHTTPRequest(buf) {
+            case .needMore:
+                if isComplete {
+                    // Client hung up mid-request. Nothing to do.
+                    connection.cancel()
+                    return
                 }
-            } else {
-                self.sendHTTP(connection, body: "{\"status\":\"ok\"}")
+                self.readRequest(connection: connection, buffer: buf)
+
+            case .done(let request):
+                self.dispatch(connection: connection, request: request)
+
+            case .invalid(let reason):
+                print("[DynamicIsland] malformed HTTP request: \(reason)")
+                self.sendHTTP(
+                    connection,
+                    body: Self.errorBody(code: "malformed_request", message: reason),
+                    statusCode: "400 Bad Request"
+                )
             }
         }
+    }
+
+    /// Route a fully-parsed HTTP request. Same semantics as the original
+    /// `handleConnection` switch — just unblocked from read-loop concerns.
+    private func dispatch(connection: NWConnection, request: HTTPRequest) {
+        if request.path.hasPrefix("/response") {
+            handleResponsePoll(connection)
+        } else if request.path.hasPrefix("/event") {
+            do {
+                guard !request.body.isEmpty else {
+                    throw EventError.missingBody
+                }
+                try processEvent(request.body)
+                sendHTTP(connection, body: "{\"status\":\"ok\"}")
+            } catch {
+                let eventError = error as? EventError
+                let code = eventError?.code ?? "internal_error"
+                let message = eventError?.message ?? "\(error)"
+                print("[DynamicIsland] /event error [\(code)]: \(message)")
+                sendHTTP(
+                    connection,
+                    body: Self.errorBody(code: code, message: message),
+                    statusCode: "400 Bad Request"
+                )
+            }
+        } else {
+            sendHTTP(connection, body: "{\"status\":\"ok\"}")
+        }
+    }
+
+    // MARK: - HTTP parsing
+
+    /// Fully-parsed HTTP request ready for dispatch.
+    struct HTTPRequest {
+        let method: String
+        let path: String
+        let headers: [String: String]   // keys lowercased
+        let body: Data
+    }
+
+    enum HTTPParseResult {
+        case needMore                   // keep reading
+        case done(HTTPRequest)
+        case invalid(String)            // 400 Bad Request
+    }
+
+    /// Pure parser: given whatever bytes we've accumulated so far, decide
+    /// whether we have a complete request, need more bytes, or should reject.
+    ///
+    /// Rules:
+    /// - Headers end at the first `\r\n\r\n`.
+    /// - Body length = `Content-Length` header (defaults to 0 if absent).
+    /// - `Content-Length: 0` (or absent) → request is complete as soon as
+    ///   headers are in hand. This is the `GET /response` path.
+    /// - Non-numeric / negative Content-Length → `invalid`.
+    /// - Request line with no space-separated method/path → `invalid`.
+    static func parseHTTPRequest(_ data: Data) -> HTTPParseResult {
+        // Find header/body separator. ASCII-safe: don't go through String.
+        let sep: [UInt8] = [0x0d, 0x0a, 0x0d, 0x0a]
+        guard let sepRange = data.range(of: Data(sep)) else {
+            return .needMore
+        }
+
+        let headerBytes = data.subdata(in: 0..<sepRange.lowerBound)
+        guard let headerStr = String(data: headerBytes, encoding: .utf8) else {
+            return .invalid("headers are not valid UTF-8")
+        }
+
+        let lines = headerStr.components(separatedBy: "\r\n")
+        guard let requestLine = lines.first else {
+            return .invalid("empty request")
+        }
+        let requestParts = requestLine.split(separator: " ", maxSplits: 2, omittingEmptySubsequences: false)
+        guard requestParts.count >= 2 else {
+            return .invalid("malformed request line: \(requestLine)")
+        }
+        let method = String(requestParts[0])
+        let path = String(requestParts[1])
+
+        var headers: [String: String] = [:]
+        for line in lines.dropFirst() where !line.isEmpty {
+            guard let colon = line.firstIndex(of: ":") else { continue }
+            let name = line[..<colon].lowercased()
+            let value = line[line.index(after: colon)...].trimmingCharacters(in: .whitespaces)
+            headers[name] = value
+        }
+
+        let expectedBodyLen: Int
+        if let raw = headers["content-length"] {
+            guard let n = Int(raw), n >= 0 else {
+                return .invalid("invalid Content-Length: \(raw)")
+            }
+            expectedBodyLen = n
+        } else {
+            expectedBodyLen = 0
+        }
+
+        let bodyStart = sepRange.upperBound
+        let bodyAvailable = data.count - bodyStart
+        if bodyAvailable < expectedBodyLen {
+            return .needMore
+        }
+
+        let body = expectedBodyLen == 0
+            ? Data()
+            : data.subdata(in: bodyStart..<(bodyStart + expectedBodyLen))
+        return .done(HTTPRequest(method: method, path: path, headers: headers, body: body))
     }
 
     /// Errors surfaced to POST /event callers so a bad payload no longer

--- a/Sources/DynamicIsland/LocalServer.swift
+++ b/Sources/DynamicIsland/LocalServer.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Network
+import DynamicIslandCore
 
 /// Lightweight HTTP server that receives Claude Code hook events.
 /// Listens on a configurable port (default 9423) for POST /event requests.
@@ -111,13 +112,7 @@ class LocalServer {
             var buf = buffer
             if let chunk = chunk { buf.append(chunk) }
 
-            if buf.count > Self.maxRequestBytes {
-                print("[DynamicIsland] request exceeded \(Self.maxRequestBytes) bytes — dropping")
-                connection.cancel()
-                return
-            }
-
-            switch Self.parseHTTPRequest(buf) {
+            switch HTTPParser.parse(buf, maxTotalBytes: Self.maxRequestBytes) {
             case .needMore:
                 if isComplete {
                     // Client hung up mid-request. Nothing to do.
@@ -135,6 +130,17 @@ class LocalServer {
                     connection,
                     body: Self.errorBody(code: "malformed_request", message: reason),
                     statusCode: "400 Bad Request"
+                )
+
+            case .tooLarge:
+                // Fail fast: headers + declared Content-Length exceed our cap,
+                // or headers alone are pathologically large.
+                print("[DynamicIsland] request exceeded \(Self.maxRequestBytes) bytes — rejecting")
+                self.sendHTTP(
+                    connection,
+                    body: Self.errorBody(code: "payload_too_large",
+                                         message: "request exceeds \(Self.maxRequestBytes) bytes"),
+                    statusCode: "413 Payload Too Large"
                 )
             }
         }
@@ -166,85 +172,6 @@ class LocalServer {
         } else {
             sendHTTP(connection, body: "{\"status\":\"ok\"}")
         }
-    }
-
-    // MARK: - HTTP parsing
-
-    /// Fully-parsed HTTP request ready for dispatch.
-    struct HTTPRequest {
-        let method: String
-        let path: String
-        let headers: [String: String]   // keys lowercased
-        let body: Data
-    }
-
-    enum HTTPParseResult {
-        case needMore                   // keep reading
-        case done(HTTPRequest)
-        case invalid(String)            // 400 Bad Request
-    }
-
-    /// Pure parser: given whatever bytes we've accumulated so far, decide
-    /// whether we have a complete request, need more bytes, or should reject.
-    ///
-    /// Rules:
-    /// - Headers end at the first `\r\n\r\n`.
-    /// - Body length = `Content-Length` header (defaults to 0 if absent).
-    /// - `Content-Length: 0` (or absent) → request is complete as soon as
-    ///   headers are in hand. This is the `GET /response` path.
-    /// - Non-numeric / negative Content-Length → `invalid`.
-    /// - Request line with no space-separated method/path → `invalid`.
-    static func parseHTTPRequest(_ data: Data) -> HTTPParseResult {
-        // Find header/body separator. ASCII-safe: don't go through String.
-        let sep: [UInt8] = [0x0d, 0x0a, 0x0d, 0x0a]
-        guard let sepRange = data.range(of: Data(sep)) else {
-            return .needMore
-        }
-
-        let headerBytes = data.subdata(in: 0..<sepRange.lowerBound)
-        guard let headerStr = String(data: headerBytes, encoding: .utf8) else {
-            return .invalid("headers are not valid UTF-8")
-        }
-
-        let lines = headerStr.components(separatedBy: "\r\n")
-        guard let requestLine = lines.first else {
-            return .invalid("empty request")
-        }
-        let requestParts = requestLine.split(separator: " ", maxSplits: 2, omittingEmptySubsequences: false)
-        guard requestParts.count >= 2 else {
-            return .invalid("malformed request line: \(requestLine)")
-        }
-        let method = String(requestParts[0])
-        let path = String(requestParts[1])
-
-        var headers: [String: String] = [:]
-        for line in lines.dropFirst() where !line.isEmpty {
-            guard let colon = line.firstIndex(of: ":") else { continue }
-            let name = line[..<colon].lowercased()
-            let value = line[line.index(after: colon)...].trimmingCharacters(in: .whitespaces)
-            headers[name] = value
-        }
-
-        let expectedBodyLen: Int
-        if let raw = headers["content-length"] {
-            guard let n = Int(raw), n >= 0 else {
-                return .invalid("invalid Content-Length: \(raw)")
-            }
-            expectedBodyLen = n
-        } else {
-            expectedBodyLen = 0
-        }
-
-        let bodyStart = sepRange.upperBound
-        let bodyAvailable = data.count - bodyStart
-        if bodyAvailable < expectedBodyLen {
-            return .needMore
-        }
-
-        let body = expectedBodyLen == 0
-            ? Data()
-            : data.subdata(in: bodyStart..<(bodyStart + expectedBodyLen))
-        return .done(HTTPRequest(method: method, path: path, headers: headers, body: body))
     }
 
     /// Errors surfaced to POST /event callers so a bad payload no longer

--- a/Sources/DynamicIslandCore/HTTPParser.swift
+++ b/Sources/DynamicIslandCore/HTTPParser.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+/// A fully-parsed HTTP/1.x request ready for dispatch. Minimal — just
+/// what `LocalServer` needs to route `/event` vs `/response` and hand
+/// the body to `processEvent`.
+public struct HTTPRequest: Equatable {
+    public let method: String
+    public let path: String
+    /// Header names are lowercased for case-insensitive lookup.
+    public let headers: [String: String]
+    public let body: Data
+
+    public init(method: String, path: String, headers: [String: String], body: Data) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
+}
+
+public enum HTTPParseResult: Equatable {
+    /// Headers or body are still incomplete — caller should keep reading.
+    case needMore
+    /// Full request in hand.
+    case done(HTTPRequest)
+    /// Framing error — reject with 400.
+    case invalid(String)
+    /// Declared `Content-Length` + headers exceeds the caller's cap —
+    /// reject with 413 without reading the body.
+    case tooLarge
+}
+
+/// Pure HTTP/1.x request framing. Handles partial buffers (TCP delivers
+/// a byte stream; a single `recv` may return headers only, headers
+/// plus part of the body, multiple concatenated requests on a
+/// keep-alive connection, etc.). Caller passes in everything received
+/// so far and re-calls on each new chunk.
+public enum HTTPParser {
+    /// Parse whatever's been accumulated so far.
+    ///
+    /// - Parameter data: bytes received so far on the connection.
+    /// - Parameter maxTotalBytes: upper bound on `header-bytes + Content-Length`.
+    ///   Returns `.tooLarge` without reading the body if declared size exceeds it.
+    public static func parse(_ data: Data, maxTotalBytes: Int) -> HTTPParseResult {
+        let sep: [UInt8] = [0x0d, 0x0a, 0x0d, 0x0a]
+        guard let sepRange = data.range(of: Data(sep)) else {
+            // Headers not yet complete. If we've already buffered more than
+            // the caller's cap just looking for the separator, bail out
+            // rather than keep reading forever.
+            if data.count > maxTotalBytes {
+                return .tooLarge
+            }
+            return .needMore
+        }
+
+        let headerBytes = data.subdata(in: 0..<sepRange.lowerBound)
+        guard let headerStr = String(data: headerBytes, encoding: .utf8) else {
+            return .invalid("headers are not valid UTF-8")
+        }
+
+        let lines = headerStr.components(separatedBy: "\r\n")
+        guard let requestLine = lines.first else {
+            return .invalid("empty request")
+        }
+        let parts = requestLine.split(separator: " ", maxSplits: 2, omittingEmptySubsequences: false)
+        guard parts.count >= 2 else {
+            return .invalid("malformed request line: \(requestLine)")
+        }
+        let method = String(parts[0])
+        let path = String(parts[1])
+
+        var headers: [String: String] = [:]
+        var contentLengthValues: [String] = []
+        var transferEncodingValues: [String] = []
+        for line in lines.dropFirst() where !line.isEmpty {
+            guard let colon = line.firstIndex(of: ":") else { continue }
+            let name = line[..<colon].lowercased()
+            let value = line[line.index(after: colon)...].trimmingCharacters(in: .whitespaces)
+            switch name {
+            case "content-length":
+                contentLengthValues.append(value)
+            case "transfer-encoding":
+                if !value.isEmpty { transferEncodingValues.append(value) }
+            default:
+                headers[name] = value
+            }
+        }
+
+        // HTTP/1.1 (RFC 7230 §3.3.3): if both Transfer-Encoding and
+        // Content-Length are present, or Transfer-Encoding is anything
+        // we don't decode, that's framing ambiguity — reject.
+        // Chunked decoding is not implemented, so any Transfer-Encoding
+        // is a hard reject.
+        if !transferEncodingValues.isEmpty {
+            return .invalid("Transfer-Encoding not supported")
+        }
+
+        let expectedBodyLen: Int
+        if contentLengthValues.isEmpty {
+            expectedBodyLen = 0
+        } else {
+            // RFC 7230 §3.3.2: duplicate Content-Length values are only
+            // acceptable if they agree. Safer here: reject duplicates
+            // outright unless they're bit-identical.
+            guard Set(contentLengthValues).count == 1 else {
+                return .invalid("conflicting Content-Length values: \(contentLengthValues)")
+            }
+            guard let n = Int(contentLengthValues[0]), n >= 0 else {
+                return .invalid("invalid Content-Length: \(contentLengthValues[0])")
+            }
+            expectedBodyLen = n
+        }
+
+        // Fail fast on declared oversize, before buffering more body.
+        let totalDeclared = sepRange.upperBound + expectedBodyLen
+        if totalDeclared > maxTotalBytes {
+            return .tooLarge
+        }
+
+        let bodyStart = sepRange.upperBound
+        let bodyAvailable = data.count - bodyStart
+        if bodyAvailable < expectedBodyLen {
+            return .needMore
+        }
+
+        if let clValue = contentLengthValues.first {
+            headers["content-length"] = clValue
+        }
+
+        let body = expectedBodyLen == 0
+            ? Data()
+            : data.subdata(in: bodyStart..<(bodyStart + expectedBodyLen))
+        return .done(HTTPRequest(method: method, path: path, headers: headers, body: body))
+    }
+}

--- a/Sources/DynamicIslandCore/HTTPParser.swift
+++ b/Sources/DynamicIslandCore/HTTPParser.swift
@@ -36,14 +36,21 @@ public enum HTTPParseResult: Equatable {
 /// keep-alive connection, etc.). Caller passes in everything received
 /// so far and re-calls on each new chunk.
 public enum HTTPParser {
+    private static let headerBodySeparator = Data([0x0d, 0x0a, 0x0d, 0x0a])
+
     /// Parse whatever's been accumulated so far.
     ///
     /// - Parameter data: bytes received so far on the connection.
     /// - Parameter maxTotalBytes: upper bound on `header-bytes + Content-Length`.
     ///   Returns `.tooLarge` without reading the body if declared size exceeds it.
+    ///
+    /// Headers are decoded as UTF-8. RFC 7230 technically allows
+    /// ISO-8859-1 in field values, but every client that talks to this
+    /// localhost server (`curl`, `URLSession`, the Swift hook binary)
+    /// emits ASCII-only headers, so strict UTF-8 is an acceptable
+    /// simplification.
     public static func parse(_ data: Data, maxTotalBytes: Int) -> HTTPParseResult {
-        let sep: [UInt8] = [0x0d, 0x0a, 0x0d, 0x0a]
-        guard let sepRange = data.range(of: Data(sep)) else {
+        guard let sepRange = data.range(of: headerBodySeparator) else {
             // Headers not yet complete. If we've already buffered more than
             // the caller's cap just looking for the separator, bail out
             // rather than keep reading forever.
@@ -70,45 +77,39 @@ public enum HTTPParser {
         let path = String(parts[1])
 
         var headers: [String: String] = [:]
-        var contentLengthValues: [String] = []
-        var transferEncodingValues: [String] = []
+        var seenContentLength: String?
+        var hasTransferEncoding = false
         for line in lines.dropFirst() where !line.isEmpty {
             guard let colon = line.firstIndex(of: ":") else { continue }
             let name = line[..<colon].lowercased()
             let value = line[line.index(after: colon)...].trimmingCharacters(in: .whitespaces)
             switch name {
             case "content-length":
-                contentLengthValues.append(value)
+                // RFC 7230 §3.3.2: duplicate values only acceptable if they agree.
+                if let previous = seenContentLength, previous != value {
+                    return .invalid("conflicting Content-Length: \(previous) vs \(value)")
+                }
+                seenContentLength = value
             case "transfer-encoding":
-                if !value.isEmpty { transferEncodingValues.append(value) }
+                if !value.isEmpty { hasTransferEncoding = true }
             default:
                 headers[name] = value
             }
         }
 
-        // HTTP/1.1 (RFC 7230 §3.3.3): if both Transfer-Encoding and
-        // Content-Length are present, or Transfer-Encoding is anything
-        // we don't decode, that's framing ambiguity — reject.
-        // Chunked decoding is not implemented, so any Transfer-Encoding
-        // is a hard reject.
-        if !transferEncodingValues.isEmpty {
+        // TE without a decoder is a framing hazard — reject.
+        if hasTransferEncoding {
             return .invalid("Transfer-Encoding not supported")
         }
 
         let expectedBodyLen: Int
-        if contentLengthValues.isEmpty {
-            expectedBodyLen = 0
-        } else {
-            // RFC 7230 §3.3.2: duplicate Content-Length values are only
-            // acceptable if they agree. Safer here: reject duplicates
-            // outright unless they're bit-identical.
-            guard Set(contentLengthValues).count == 1 else {
-                return .invalid("conflicting Content-Length values: \(contentLengthValues)")
-            }
-            guard let n = Int(contentLengthValues[0]), n >= 0 else {
-                return .invalid("invalid Content-Length: \(contentLengthValues[0])")
+        if let raw = seenContentLength {
+            guard let n = Int(raw), n >= 0 else {
+                return .invalid("invalid Content-Length: \(raw)")
             }
             expectedBodyLen = n
+        } else {
+            expectedBodyLen = 0
         }
 
         // Fail fast on declared oversize, before buffering more body.
@@ -121,10 +122,6 @@ public enum HTTPParser {
         let bodyAvailable = data.count - bodyStart
         if bodyAvailable < expectedBodyLen {
             return .needMore
-        }
-
-        if let clValue = contentLengthValues.first {
-            headers["content-length"] = clValue
         }
 
         let body = expectedBodyLen == 0

--- a/Tests/DynamicIslandCoreTests/HTTPParserTests.swift
+++ b/Tests/DynamicIslandCoreTests/HTTPParserTests.swift
@@ -1,0 +1,168 @@
+import XCTest
+@testable import DynamicIslandCore
+
+final class HTTPParserTests: XCTestCase {
+    private let cap = 1_048_576  // 1 MiB — matches LocalServer's production cap
+
+    // MARK: - Happy paths
+
+    func testCompletePostWithBody() {
+        let body = #"{"title":"ok"}"#
+        let raw = """
+        POST /event HTTP/1.1\r
+        Host: 127.0.0.1:9423\r
+        Content-Length: \(body.utf8.count)\r
+        Content-Type: application/json\r
+        \r
+        \(body)
+        """
+        let result = HTTPParser.parse(Data(raw.utf8), maxTotalBytes: cap)
+        guard case .done(let req) = result else {
+            return XCTFail("expected .done, got \(result)")
+        }
+        XCTAssertEqual(req.method, "POST")
+        XCTAssertEqual(req.path, "/event")
+        XCTAssertEqual(req.body, Data(body.utf8))
+        XCTAssertEqual(req.headers["content-type"], "application/json")
+    }
+
+    func testCompleteGetNoBody() {
+        let raw = "GET /response HTTP/1.1\r\nHost: localhost\r\n\r\n"
+        let result = HTTPParser.parse(Data(raw.utf8), maxTotalBytes: cap)
+        guard case .done(let req) = result else {
+            return XCTFail("expected .done, got \(result)")
+        }
+        XCTAssertEqual(req.method, "GET")
+        XCTAssertEqual(req.path, "/response")
+        XCTAssertTrue(req.body.isEmpty)
+    }
+
+    func testMissingContentLengthTreatedAsZero() {
+        let raw = "POST /event HTTP/1.1\r\nHost: localhost\r\n\r\n"
+        let result = HTTPParser.parse(Data(raw.utf8), maxTotalBytes: cap)
+        guard case .done(let req) = result else {
+            return XCTFail("expected .done, got \(result)")
+        }
+        XCTAssertTrue(req.body.isEmpty)
+    }
+
+    // MARK: - Partial reads
+
+    func testHeadersIncomplete_NeedMore() {
+        let raw = "POST /event HTTP/1.1\r\nHost: localhost\r\nContent-Le"
+        let result = HTTPParser.parse(Data(raw.utf8), maxTotalBytes: cap)
+        XCTAssertEqual(result, .needMore)
+    }
+
+    func testHeadersCompleteBodyIncomplete_NeedMore() {
+        // Content-Length says 10, body only has 3.
+        let raw = "POST /event HTTP/1.1\r\nContent-Length: 10\r\n\r\nabc"
+        let result = HTTPParser.parse(Data(raw.utf8), maxTotalBytes: cap)
+        XCTAssertEqual(result, .needMore)
+    }
+
+    /// The original bug: header/body split across two receive callbacks.
+    /// Parser should see first buffer as `.needMore`, second as `.done`.
+    func testSplitBodyArrivesInTwoChunks() {
+        let body = #"{"x":1}"#
+        let headers = "POST /event HTTP/1.1\r\nContent-Length: \(body.utf8.count)\r\n\r\n"
+
+        let afterHeaders = HTTPParser.parse(Data(headers.utf8), maxTotalBytes: cap)
+        XCTAssertEqual(afterHeaders, .needMore)
+
+        var combined = Data(headers.utf8)
+        combined.append(Data(body.utf8))
+        guard case .done(let req) = HTTPParser.parse(combined, maxTotalBytes: cap) else {
+            return XCTFail("expected .done on second chunk")
+        }
+        XCTAssertEqual(req.body, Data(body.utf8))
+    }
+
+    // MARK: - Framing errors
+
+    func testInvalidContentLength_NonNumeric() {
+        let raw = "POST /event HTTP/1.1\r\nContent-Length: ten\r\n\r\n"
+        let result = HTTPParser.parse(Data(raw.utf8), maxTotalBytes: cap)
+        if case .invalid = result { return }
+        XCTFail("expected .invalid, got \(result)")
+    }
+
+    func testInvalidContentLength_Negative() {
+        let raw = "POST /event HTTP/1.1\r\nContent-Length: -5\r\n\r\n"
+        let result = HTTPParser.parse(Data(raw.utf8), maxTotalBytes: cap)
+        if case .invalid = result { return }
+        XCTFail("expected .invalid, got \(result)")
+    }
+
+    func testConflictingDuplicateContentLength_Invalid() {
+        let raw = """
+        POST /event HTTP/1.1\r
+        Content-Length: 10\r
+        Content-Length: 20\r
+        \r
+
+        """
+        let result = HTTPParser.parse(Data(raw.utf8), maxTotalBytes: cap)
+        if case .invalid = result { return }
+        XCTFail("expected .invalid on conflicting Content-Length, got \(result)")
+    }
+
+    func testDuplicateContentLengthSameValue_Accepted() {
+        // RFC 7230: duplicates are OK if they agree. Body length 0 so
+        // there's nothing else to check.
+        let raw = """
+        POST /event HTTP/1.1\r
+        Content-Length: 0\r
+        Content-Length: 0\r
+        \r
+
+        """
+        let result = HTTPParser.parse(Data(raw.utf8), maxTotalBytes: cap)
+        if case .done = result { return }
+        XCTFail("expected .done for identical duplicate Content-Length, got \(result)")
+    }
+
+    func testTransferEncodingRejected() {
+        // We don't decode chunked, and TE without decoder is a framing hazard.
+        let raw = "POST /event HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n"
+        let result = HTTPParser.parse(Data(raw.utf8), maxTotalBytes: cap)
+        if case .invalid(let msg) = result, msg.contains("Transfer-Encoding") { return }
+        XCTFail("expected .invalid about Transfer-Encoding, got \(result)")
+    }
+
+    func testMalformedRequestLine() {
+        let raw = "GIBBERISH\r\n\r\n"
+        let result = HTTPParser.parse(Data(raw.utf8), maxTotalBytes: cap)
+        if case .invalid = result { return }
+        XCTFail("expected .invalid, got \(result)")
+    }
+
+    // MARK: - Oversize
+
+    func testDeclaredOversize_FailsFastBeforeReadingBody() {
+        // Content-Length greatly exceeds cap. Parser should reject at
+        // header-parse time without requiring caller to buffer the body.
+        let raw = "POST /event HTTP/1.1\r\nContent-Length: 999999999\r\n\r\n"
+        let result = HTTPParser.parse(Data(raw.utf8), maxTotalBytes: 1024)
+        XCTAssertEqual(result, .tooLarge)
+    }
+
+    func testHeadersAloneExceedCap_TooLarge() {
+        // Headers never complete and exceed cap → reject rather than
+        // accumulating forever.
+        let huge = String(repeating: "X", count: 2000)
+        let raw = "POST /event HTTP/1.1\r\nHost: \(huge)"
+        let result = HTTPParser.parse(Data(raw.utf8), maxTotalBytes: 1024)
+        XCTAssertEqual(result, .tooLarge)
+    }
+
+    func testExactlyAtCap_Accepted() {
+        let body = "x"  // 1 byte
+        let headers = "POST /event HTTP/1.1\r\nContent-Length: 1\r\n\r\n"
+        let total = Data(headers.utf8).count + 1
+        let raw = headers + body
+        let result = HTTPParser.parse(Data(raw.utf8), maxTotalBytes: total)
+        if case .done = result { return }
+        XCTFail("request at exactly cap should parse, got \(result)")
+    }
+}


### PR DESCRIPTION
Closes #14

## Summary

`LocalServer.handleConnection` called `connection.receive()` exactly once per TCP connection and treated the returned bytes as one complete HTTP request. That assumption is wrong for any TCP stream — `receive(minimumIncompleteLength:maximumLength:)` is documented as a single-shot delivery. The Swift `island-hook` binary (via `URLSession.shared.dataTask`) routinely triggers this on loopback: the first callback delivers headers only, the body is never read, and the server errors out with `missing_body`. Hook events silently drop.

Instrumentation confirmed the rate is high — most Claude Code hook POSTs fail. Users see "notch doesn't always appear." See #14 for the captured logs.

## What this PR does

Reads HTTP requests across multiple TCP chunks. The parser is extracted as a pure function with unit tests, and HTTP framing is hardened per the RFC.

## Behavior

| Case | Before | After |
|------|--------|-------|
| Full request in one chunk (curl) | 200 | 200 (byte-identical) |
| Headers + body in separate chunks (URLSession) | 400 `missing_body` | 200 |
| `POST /event` with declared `Content-Length` > 1 MiB | Silent cancel after buffering to cap | 413 `payload_too_large`, fail-fast (no body read) |
| Conflicting `Content-Length: 10` + `Content-Length: 20` | Second value silently overwrote first | 400 `malformed_request` (per RFC 7230 §3.3.2) |
| `Transfer-Encoding: chunked` | Accepted; Content-Length header read as body framing (ambiguity) | 400 `malformed_request` (chunked decoding not implemented) |
| `GET /response` | 200 long-poll | 200 long-poll (unchanged) |

Success paths for existing callers (`curl`, the hook binary) are behaviorally identical on valid requests — they just stop losing events to the single-chunk bug.

## Implementation (4 commits)

1. **`fix(LocalServer)`** — Rewrite `handleConnection` to loop `receive()` until the full request is buffered. Short-circuits on client disconnect. 1 MiB per-request cap.
2. **`refactor(LocalServer)`** — After external review, extract `HTTPParser` into a new `DynamicIslandCore` library target (mirrors the existing `IslandHookCore` pattern). Adds 15 `HTTPParserTests` covering split reads, framing errors, duplicate / conflicting Content-Length, Transfer-Encoding, and oversize. Fail fast on declared oversize (413 instead of buffer-then-cancel). Reject Transfer-Encoding and conflicting duplicate Content-Length.
3. **`refactor(HTTPParser): simplify`** — Post-review cleanup: lift header/body separator to a static `Data` constant, replace `Set`-based duplicate-CL check with a scalar `seenContentLength?`, collapse `transferEncodingValues` list to a `Bool`, drop the "strip then re-insert Content-Length in the headers dict" dance (no consumer reads it), trim comments.
4. **`chore(.gitignore)`** — Exclude local-only dev-doc staging directories (`.issues/`, `docs/superpowers/`, `.superpowers/`) so they never leak into commits.

## Test plan

- [x] `swift test` — 68 existing `IslandHookCore` tests still pass; 15 new `HTTPParser` tests pass (83 total, 0 failures)
- [x] `swift build` — clean on debug
- [x] `curl -d '...'` (full request one chunk) → 200, event renders (smoke test)
- [x] Manual `URLSession` POST (common split-chunk trigger) → 200, event renders; **before fix: 400 `missing_body`**
- [x] Adversarial raw-socket send: write headers, `sleep 100ms`, write body → 200, event renders; **before fix: 400**
- [x] Real `island-hook` binary against the fixed server: `DYNAMIC_ISLAND_DEBUG_LOG` shows zero `missing_body` errors; **before fix: ~80% of POSTs failed**
- [ ] Multi-day soak in production builds — not yet done

## Design notes

External review (codex) confirmed the diagnosis and direction. Key discussion points, resolved:

- **Parser location**: lives in `DynamicIslandCore`, the new pure-Swift library target. Same pattern as `IslandHookCore`. The executable target depends on it; unit tests reach it directly.
- **Transfer-Encoding handling**: unconditional reject. Chunked decoding isn't implemented, and `TE` + `CL` together is framing ambiguity (RFC 7230 §3.3.3).
- **UTF-8 headers**: the parser decodes headers as UTF-8. RFC 7230 technically allows ISO-8859-1 field values, but every realistic client here emits ASCII (`curl`, `URLSession`, the hook binary). Documented as an assumption inline.
- **Method enforcement**: out of scope. Currently the server routes by path prefix and ignores method; `GET /event` still falls through to the `/event` handler, which then returns 400 because the body is empty. Tightening this (reject with 405) is worth a follow-up but doesn't affect the bug fix.

## Out of scope

- Switching the hook to a different HTTP client. `URLSession` is Foundation-only, zero-dep, and the right choice post v1.4.3. The server should handle any TCP client correctly, not work around one.
- Chunked transfer-encoding support.
- Method-based routing (405 on `GET /event`, etc.).
