### PR TITLE
feat(capsule): source dot, project-aware subtitle, scrollable detail

### DIFF
--- a/Sources/DynamicIsland/IslandState.swift
+++ b/Sources/DynamicIsland/IslandState.swift
@@ -83,6 +83,8 @@ enum EventStyle: String, Codable {
     case action // Needs user attention — persistent, pulsing, with buttons
     case reminder // Needs attention — pulsing, but no buttons
 
+    var isPulsing: Bool { self == .action || self == .reminder }
+
     var color: Color {
         switch self {
         case .info: return .white
@@ -170,10 +172,13 @@ enum IslandMode: Equatable {
             case .hidden: return CGSize(width: w, height: IslandPanel.notchHeight + 30)
             }
         } else {
+            // Sizes include a transparent margin around the pill so the
+            // drop shadow / pulse border can render without clipping at
+            // the window edge, and so clicks fall through beside the pill.
             switch self {
-            case .compact: return CGSize(width: 210, height: 38)
-            case .expanded: return CGSize(width: 380, height: 140 + treeExtra + detailExtra)
-            case .hidden: return CGSize(width: 210, height: 38)
+            case .compact: return CGSize(width: 260, height: 68)
+            case .expanded: return CGSize(width: 420, height: 210 + treeExtra + detailExtra)
+            case .hidden: return CGSize(width: 260, height: 68)
             }
         }
     }

--- a/Sources/DynamicIsland/IslandView.swift
+++ b/Sources/DynamicIsland/IslandView.swift
@@ -95,16 +95,19 @@ struct IslandRootView: View {
     @ViewBuilder
     private var fallbackLayout: some View {
         if stateManager.mode != .hidden, let event = stateManager.currentEvent {
-            switch stateManager.mode {
-            case .compact:
-                CompactPillView(event: event, stateManager: stateManager)
-                    .transition(.scale(scale: 0.8).combined(with: .opacity))
-            case .expanded:
-                ExpandedPillView(event: event, stateManager: stateManager)
-                    .transition(.scale(scale: 0.95).combined(with: .opacity))
-            default:
-                EmptyView()
+            Group {
+                switch stateManager.mode {
+                case .compact:
+                    CompactPillView(event: event, stateManager: stateManager)
+                        .transition(.scale(scale: 0.8).combined(with: .opacity))
+                case .expanded:
+                    ExpandedPillView(event: event, stateManager: stateManager)
+                        .transition(.scale(scale: 0.95).combined(with: .opacity))
+                default:
+                    EmptyView()
+                }
             }
+            .padding(12)
         }
     }
 }
@@ -498,11 +501,17 @@ struct CompactPillView: View {
 struct ExpandedPillView: View {
     let event: IslandEvent
     @ObservedObject var stateManager: IslandStateManager
+    @State private var actionPulse = false
+
+    private var isPulsing: Bool { event.style.isPulsing }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text(event.icon).font(.system(size: 22))
+            HStack(spacing: 10) {
+                if !event.icon.isEmpty {
+                    Text(event.icon).font(.system(size: 22))
+                }
+
                 VStack(alignment: .leading, spacing: 2) {
                     Text(event.title)
                         .font(.system(size: 14, weight: .bold, design: .rounded))
@@ -523,24 +532,55 @@ struct ExpandedPillView: View {
             }
 
             if let detail = event.detail {
-                Text(detail)
-                    .font(.system(size: 12, design: .monospaced))
-                    .foregroundColor(.white.opacity(0.8))
-                    .lineLimit(3)
-                    .padding(8)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(RoundedRectangle(cornerRadius: 8).fill(Color.white.opacity(0.08)))
+                DiffDetailView(text: detail)
+            }
+
+            if event.style == .action {
+                PermissionActionButtons(stateManager: stateManager)
+            }
+
+            if let progress = event.progress {
+                LinearProgressBar(progress: progress, color: event.style.color)
             }
         }
         .padding(16)
-        .frame(width: 380, height: 140)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
         .background(
             RoundedRectangle(cornerRadius: 22)
                 .fill(.black)
-                .overlay(RoundedRectangle(cornerRadius: 22).strokeBorder(event.style.glowColor, lineWidth: 1))
-                .shadow(color: event.style.glowColor, radius: 12, y: 4)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 22)
+                        .strokeBorder(
+                            isPulsing
+                                ? (event.projectColor ?? event.style.color).opacity(actionPulse ? 0.85 : 0.25)
+                                : event.style.glowColor,
+                            lineWidth: isPulsing ? 1.5 : 1
+                        )
+                )
+                .shadow(
+                    color: isPulsing
+                        ? (event.projectColor ?? event.style.color).opacity(actionPulse ? 0.55 : 0.15)
+                        : event.style.glowColor,
+                    radius: 12, y: 4
+                )
         )
-        .onTapGesture { stateManager.collapse() }
+        .onTapGesture {
+            // Don't collapse on action — the user must pick Allow or Deny.
+            if event.style == .action { return }
+            stateManager.collapse()
+        }
+        .onAppear { updateActionPulse() }
+        .onChange(of: event.id) { _ in updateActionPulse() }
+    }
+
+    private func updateActionPulse() {
+        if isPulsing {
+            withAnimation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true)) {
+                actionPulse = true
+            }
+        } else {
+            actionPulse = false
+        }
     }
 }
 
@@ -668,6 +708,70 @@ struct SessionRow: View {
     private var activityText: String {
         if session.lastSubtitle.isEmpty { return session.lastTitle }
         return "\(session.lastTitle) · \(session.lastSubtitle)"
+    }
+}
+
+// MARK: - Permission Action Buttons (shared by notch + capsule expanded)
+
+struct PermissionActionButtons: View {
+    @ObservedObject var stateManager: IslandStateManager
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Button(action: {
+                stateManager.server?.setResponse("allow")
+                stateManager.dismiss()
+            }) {
+                Text("Allow")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(Color(red: 0.2, green: 0.5, blue: 1.0))
+                    )
+            }
+            .buttonStyle(.plain)
+
+            Button(action: {
+                stateManager.server?.setResponse("deny")
+                stateManager.dismiss()
+            }) {
+                Text("Deny")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(.white.opacity(0.8))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(Color.white.opacity(0.1))
+                    )
+            }
+            .buttonStyle(.plain)
+        }
+    }
+}
+
+// MARK: - Linear Progress Bar (shared by notch + capsule expanded)
+
+struct LinearProgressBar: View {
+    let progress: Double
+    let color: Color
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(Color.white.opacity(0.1))
+                    .frame(height: 4)
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(color)
+                    .frame(width: geo.size.width * progress, height: 4)
+                    .animation(.easeOut(duration: 0.25), value: progress)
+            }
+        }
+        .frame(height: 4)
     }
 }
 

--- a/Sources/DynamicIsland/IslandView.swift
+++ b/Sources/DynamicIsland/IslandView.swift
@@ -464,26 +464,57 @@ struct CompactPillView: View {
     @ObservedObject var stateManager: IslandStateManager
     @State private var appeared = false
 
+    /// Project prefix joined to subtitle so the pill shows which concurrent
+    /// session an event came from. The notch ear has an equivalent sublabel
+    /// via `event.project`; the capsule can't spare a second line so we
+    /// inline it.
+    private var secondaryLine: String {
+        let project = event.project ?? ""
+        switch (project.isEmpty, event.subtitle.isEmpty) {
+        case (true, true):   return ""
+        case (true, false):  return event.subtitle
+        case (false, true):  return project
+        case (false, false): return "\(project) · \(event.subtitle)"
+        }
+    }
+
     var body: some View {
         HStack(spacing: 8) {
-            Text(event.icon)
-                .font(.system(size: 16))
-                .scaleEffect(appeared ? 1.0 : 0.5)
-                .animation(.spring(response: 0.3, dampingFraction: 0.6).delay(0.1), value: appeared)
+            // Source dot — the capsule's analogue to the ear's outer stripe.
+            Circle()
+                .fill(event.projectColor ?? event.style.color)
+                .frame(width: 6, height: 6)
 
-            Text(event.title)
-                .font(.system(size: 13, weight: .semibold, design: .rounded))
-                .foregroundColor(.white)
-                .lineLimit(1)
+            if !event.icon.isEmpty {
+                Text(event.icon)
+                    .font(.system(size: 15))
+                    .scaleEffect(appeared ? 1.0 : 0.5)
+                    .animation(.spring(response: 0.3, dampingFraction: 0.6).delay(0.1), value: appeared)
+            }
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(event.title)
+                    .font(.system(size: 13, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white)
+                    .lineLimit(1)
+
+                if !secondaryLine.isEmpty {
+                    Text(secondaryLine)
+                        .font(.system(size: 10, weight: .regular))
+                        .foregroundColor(.white.opacity(0.6))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+            }
 
             if let progress = event.progress {
                 ProgressRing(progress: progress, color: event.style.color)
                     .frame(width: 18, height: 18)
             }
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 8)
-        .frame(height: 38)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 6)
+        .frame(height: secondaryLine.isEmpty ? 38 : 44)
         .background(
             Capsule()
                 .fill(.black)
@@ -532,7 +563,7 @@ struct ExpandedPillView: View {
             }
 
             if let detail = event.detail {
-                DiffDetailView(text: detail)
+                DiffDetailView(text: detail, scrollable: true)
             }
 
             if event.style == .action {
@@ -618,18 +649,47 @@ struct ThinkingPulseView: View {
 /// content renders as plain monospaced text.
 struct DiffDetailView: View {
     let text: String
+    /// When true, render all lines inside a vertical ScrollView capped at
+    /// `maxVisibleHeight`. Default false preserves the existing truncated
+    /// rendering used by the notch layout.
+    var scrollable: Bool = false
 
     private var lines: [Substring] { text.split(separator: "\n", omittingEmptySubsequences: false) }
 
+    private let maxVisibleHeight: CGFloat = 160
+
     var body: some View {
+        Group {
+            if scrollable {
+                ScrollView(.vertical, showsIndicators: true) {
+                    linesStack
+                        .padding(8)
+                }
+                .frame(maxHeight: maxVisibleHeight)
+            } else {
+                truncatedStack
+                    .padding(8)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.white.opacity(0.08))
+        )
+    }
+
+    private var linesStack: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
+                lineText(line)
+            }
+        }
+    }
+
+    private var truncatedStack: some View {
         VStack(alignment: .leading, spacing: 1) {
             ForEach(Array(lines.prefix(10).enumerated()), id: \.offset) { _, line in
-                Text(line)
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundColor(color(for: line))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                lineText(line)
             }
             if lines.count > 10 {
                 Text("… +\(lines.count - 10) more")
@@ -637,12 +697,15 @@ struct DiffDetailView: View {
                     .foregroundColor(.white.opacity(0.4))
             }
         }
-        .padding(8)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 8)
-                .fill(Color.white.opacity(0.08))
-        )
+    }
+
+    private func lineText(_ line: Substring) -> some View {
+        Text(line)
+            .font(.system(size: 11, design: .monospaced))
+            .foregroundColor(color(for: line))
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private func color(for line: Substring) -> Color {


### PR DESCRIPTION
Closes #17. Stacked on #18 — review or merge #18 first; this PR's diff
will shrink to just the feature changes once #18 lands.

## Summary

Three small gaps in the non-notch (capsule) layout that add up to "which
session pinged me?" being hard to answer on multi-display setups:

- `CompactPillView` only rendered `icon + title`, so the pill carried no
  hint of source or session. Adds a leading 6 pt source-color dot (the
  capsule's analogue to the ear's outer stripe) and prepends
  `event.project` to `event.subtitle` with a `·` separator — e.g.
  `cc-island · waiting for input`. Pill height conditionally 38 → 44 to
  fit the secondary line; the panel already reserves room from #18.

- `DiffDetailView` was capped at 10 lines with a `… +N more` tail, which
  on capsule hid most of a real diff because the detail block is often
  the only place the change is visible. `DiffDetailView` now takes a
  `scrollable: Bool = false` parameter. `ExpandedContentView` (notch)
  keeps the default — the truncated branch reconstructs the original 10-
  line + `+N more` rendering, so notch display is unchanged.
  `ExpandedPillView` (capsule) passes `true` to use a vertical
  `ScrollView` capped at 160 pt.

## Scope — notch untouched

- No visible change on notch: `ExpandedContentView`, `LeftEarView`,
  `RightEarView`, and `notchLayout` are byte-identical to `main`;
  `DiffDetailView`'s default branch matches the pre-PR rendering line
  for line.
- `buildNotificationPayload` is untouched — Notification titles remain
  `"Claude Code"`. (An earlier draft proposed renaming the title to the
  project; reverted because it would have changed the ear's title.)

## Test plan

- [x] Capsule: send a Notification-shaped event with `project` +
  `subtitle` set, verify the pill shows `● title / project · subtitle`
  on two lines with correct source color.
- [x] Capsule: send an `action` event with a 16-line diff, verify the
  detail block scrolls inside the expanded pill without pushing
  Allow/Deny off-screen.
- [x] Capsule: send events with no `project` or no `subtitle`, verify
  the secondary line collapses correctly (pill shrinks to 38 pt).
- [ ] Notch: not tested locally — the `DiffDetailView` parameter
  defaults to the existing truncation path, so notch callers should be
  unaffected.