### PR TITLE
Fix: re-render notch/capsule layout on screen change

### DIFF
--- a/Sources/DynamicIsland/App.swift
+++ b/Sources/DynamicIsland/App.swift
@@ -135,6 +135,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             queue: .main
         ) { [weak self] _ in
             self?.screenFollower.handleScreenTopologyChange()
+            // Cocoa auto-reparents orphaned windows, so `relocate(to:)` may
+            // see no work to do. Force-refresh the notch metrics anyway.
+            self?.panel?.refreshLayoutForCurrentScreen()
         }
 
         NotificationMonitor.shared.start(stateManager: stateManager)

--- a/Sources/DynamicIsland/IslandPanel.swift
+++ b/Sources/DynamicIsland/IslandPanel.swift
@@ -82,6 +82,10 @@ class IslandPanel: NSPanel {
         self.ignoresMouseEvents = true
         self.acceptsMouseMovedEvents = true
 
+        // Seed the published flag so SwiftUI's initial layout knows which
+        // variant to render. Relocations update it in the completion handler.
+        stateManager.hasNotch = hasNotch
+
         let hostView = NSHostingView(
             rootView: IslandRootView(stateManager: stateManager, panel: self)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -163,6 +167,10 @@ class IslandPanel: NSPanel {
             guard let self = self else { return }
             Self.applyScreenMetrics(target)
             let hasNotch = Self.detectHasNotch(for: target)
+            // Publish the new layout kind so SwiftUI re-renders notch vs
+            // capsule. Must happen before setFrame so the view pass sees
+            // the right `hasNotch` against the new window geometry.
+            self.stateManager.hasNotch = hasNotch
             let size = Self.adjustedSize(
                 mode: self.stateManager.mode,
                 event: self.stateManager.currentEvent,

--- a/Sources/DynamicIsland/IslandPanel.swift
+++ b/Sources/DynamicIsland/IslandPanel.swift
@@ -221,6 +221,33 @@ class IslandPanel: NSPanel {
         return size
     }
 
+    /// Re-read the current screen's notch metrics and republish them to
+    /// `stateManager.hasNotch`, then resize the frame to match. Covers the
+    /// case where an external display is disconnected: Cocoa silently
+    /// reparents the window to a remaining screen, but `relocate(to:)`
+    /// short-circuits because `self.screen` already equals the target —
+    /// so `hasNotch` would stay stuck on the unplugged display's kind and
+    /// SwiftUI would keep rendering the wrong layout.
+    func refreshLayoutForCurrentScreen() {
+        guard let screen = self.screen ?? NSScreen.main else { return }
+        Self.applyScreenMetrics(screen)
+        let hasNotch = Self.detectHasNotch(for: screen)
+        stateManager.hasNotch = hasNotch
+        let detailLines = stateManager.currentEvent?.detail
+            .map { min($0.split(separator: "\n").count, 10) } ?? 0
+        let size = Self.adjustedSize(
+            mode: stateManager.mode,
+            event: stateManager.currentEvent,
+            hasNotch: hasNotch,
+            sessionRows: stateManager.activeSessions.count,
+            detailLines: detailLines
+        )
+        let newFrame = Self.topCenteredFrame(on: screen, size: size)
+        setFrame(newFrame, display: true)
+        syncPulsePanelFrame(mainFrame: newFrame)
+        updatePulseVisibility()
+    }
+
     /// Top-centered frame on `screen`. Used by both `init` (via inline
     /// duplication for super.init ordering) and `updateSize` / `relocate`.
     static func topCenteredFrame(on screen: NSScreen, size: CGSize) -> NSRect {

--- a/Sources/DynamicIsland/IslandState.swift
+++ b/Sources/DynamicIsland/IslandState.swift
@@ -193,6 +193,11 @@ class IslandStateManager: ObservableObject {
     @Published var isThinking = false
     @Published var thinkingSource: String?
 
+    /// Whether the panel's current screen has a camera notch. Published so the
+    /// SwiftUI view tree re-renders when the panel relocates across screens
+    /// — `panel.screen` is a Cocoa property SwiftUI can't observe directly.
+    @Published var hasNotch: Bool = false
+
     /// Live view of main + subagent channels, sorted with main first
     @Published var activeSessions: [SessionChannel] = []
 

--- a/Sources/DynamicIsland/IslandView.swift
+++ b/Sources/DynamicIsland/IslandView.swift
@@ -6,7 +6,7 @@ struct IslandRootView: View {
     @ObservedObject var stateManager: IslandStateManager
     weak var panel: IslandPanel?
 
-    private var hasNotch: Bool { panel?.hasNotch ?? false }
+    private var hasNotch: Bool { stateManager.hasNotch }
 
     var body: some View {
         VStack(spacing: 0) {


### PR DESCRIPTION
Closes #21

## Summary

Fixes the "notch/capsule layout doesn't re-render on screen change" bug from #21.

`IslandRootView.hasNotch` was a plain `computed` reading `panel?.hasNotch` → `self.screen.safeAreaInsets`. `NSWindow.screen` isn't observable by SwiftUI, so the view tree had no signal to re-render after `relocate(to:)` or after Cocoa silently reparented the window on display disconnect.

## What this PR does

- **`fix(panel): re-evaluate notch-vs-capsule layout on relocate`** — Hoist `hasNotch` to a `@Published` on `IslandStateManager`, seeded during `IslandPanel.init` and re-published in `relocate(to:)`'s completion before the frame is set. Same main-queue cycle as the new frame, so SwiftUI re-renders in step.

- **`fix(panel): refresh notch layout on screen disconnect`** — Add `IslandPanel.refreshLayoutForCurrentScreen()`: unconditionally re-read the current screen's notch metrics, republish `stateManager.hasNotch`, and re-apply the frame. Wired to `didChangeScreenParametersNotification` after the screen follower runs, so the topology path no longer depends on `relocate(to:)`'s short-circuit.

## Test plan

- [x] `swift build` clean, 88 tests pass
- [x] Cursor relocate (notch ↔ capsule): layout flips on dwell as expected
- [x] Disconnect external display while capsule is showing on it: layout flips to notch ears on the survivor screen
- [x] No-notch single-screen setup: behaviour unchanged
