### PR TITLE
Promote project to primary identity in capsule and notch layouts

### DIFF
--- a/Sources/DynamicIsland/IslandView.swift
+++ b/Sources/DynamicIsland/IslandView.swift
@@ -463,19 +463,17 @@ struct CompactPillView: View {
     @ObservedObject var stateManager: IslandStateManager
     @State private var appeared = false
 
-    /// Project prefix joined to subtitle so the pill shows which concurrent
-    /// session an event came from. The notch ear has an equivalent sublabel
-    /// via `event.project`; the capsule can't spare a second line so we
-    /// inline it.
-    private var secondaryLine: String {
-        let project = event.project ?? ""
-        switch (project.isEmpty, event.subtitle.isEmpty) {
-        case (true, true):   return ""
-        case (true, false):  return event.subtitle
-        case (false, true):  return project
-        case (false, false): return "\(project) · \(event.subtitle)"
-        }
+    /// Promote `event.project` to the primary title slot whenever we have
+    /// one — multi-session users read "which session" before "what action".
+    /// Falls back to `event.title` for bare `/event` POSTs with no project.
+    private var hasProject: Bool {
+        guard let project = event.project else { return false }
+        return !project.isEmpty && project != event.title
     }
+
+    private var primaryTitle: String { hasProject ? event.project! : event.title }
+
+    private var actionChipText: String? { hasProject ? event.title : nil }
 
     var body: some View {
         HStack(spacing: 8) {
@@ -492,13 +490,26 @@ struct CompactPillView: View {
             }
 
             VStack(alignment: .leading, spacing: 1) {
-                Text(event.title)
-                    .font(.system(size: 13, weight: .semibold, design: .rounded))
-                    .foregroundColor(.white)
-                    .lineLimit(1)
+                HStack(spacing: 6) {
+                    Text(primaryTitle)
+                        .font(.system(size: 13, weight: .semibold, design: .rounded))
+                        .foregroundColor(.white)
+                        .lineLimit(1)
 
-                if !secondaryLine.isEmpty {
-                    Text(secondaryLine)
+                    if let chip = actionChipText {
+                        Text(chip)
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundColor(event.style.color)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 1)
+                            .background(
+                                Capsule().fill(event.style.color.opacity(0.18))
+                            )
+                    }
+                }
+
+                if !event.subtitle.isEmpty {
+                    Text(event.subtitle)
                         .font(.system(size: 10, weight: .regular))
                         .foregroundColor(.white.opacity(0.6))
                         .lineLimit(1)
@@ -513,7 +524,7 @@ struct CompactPillView: View {
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 6)
-        .frame(height: secondaryLine.isEmpty ? 38 : 44)
+        .frame(height: event.subtitle.isEmpty ? 38 : 44)
         .background(
             Capsule()
                 .fill(.black)
@@ -535,6 +546,13 @@ struct ExpandedPillView: View {
 
     private var isPulsing: Bool { event.style.isPulsing }
 
+    private var hasProject: Bool {
+        guard let project = event.project else { return false }
+        return !project.isEmpty && project != event.title
+    }
+
+    private var primaryTitle: String { hasProject ? event.project! : event.title }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 10) {
@@ -543,9 +561,23 @@ struct ExpandedPillView: View {
                 }
 
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(event.title)
-                        .font(.system(size: 14, weight: .bold, design: .rounded))
-                        .foregroundColor(.white)
+                    HStack(spacing: 6) {
+                        Text(primaryTitle)
+                            .font(.system(size: 14, weight: .bold, design: .rounded))
+                            .foregroundColor(.white)
+
+                        if hasProject {
+                            Text(event.title)
+                                .font(.system(size: 10, weight: .medium))
+                                .foregroundColor(event.style.color)
+                                .padding(.horizontal, 7)
+                                .padding(.vertical, 2)
+                                .background(
+                                    Capsule().fill(event.style.color.opacity(0.18))
+                                )
+                        }
+                    }
+
                     if !event.subtitle.isEmpty {
                         Text(event.subtitle)
                             .font(.system(size: 12))

--- a/Sources/DynamicIsland/IslandView.swift
+++ b/Sources/DynamicIsland/IslandView.swift
@@ -221,22 +221,22 @@ struct LeftEarView: View {
             }
 
             if isVisible, let event {
+                // EXPERIMENT: flip title/project on notch ear.
+                // Primary = project (when present), secondary = action.
+                // Source is already signalled by the outer edge stripe,
+                // so no separate dot inside the text.
+                let hasProject = (event.project?.isEmpty == false)
                 VStack(alignment: .leading, spacing: 1) {
-                    Text(event.title)
-                        .font(.system(size: event.project != nil ? 11 : 12, weight: isPulsing ? .semibold : .medium))
+                    Text(hasProject ? (event.project ?? "") : event.title)
+                        .font(.system(size: hasProject ? 11 : 12, weight: isPulsing ? .semibold : .medium))
                         .foregroundColor(isPulsing ? event.style.color : .white)
                         .lineLimit(1)
 
-                    if let project = event.project {
-                        HStack(spacing: 3) {
-                            Circle()
-                                .fill(event.projectColor ?? .white.opacity(0.4))
-                                .frame(width: 4, height: 4)
-                            Text(project)
-                                .font(.system(size: 8, weight: .regular))
-                                .foregroundColor(.white.opacity(0.4))
-                                .lineLimit(1)
-                        }
+                    if hasProject {
+                        Text(event.title)
+                            .font(.system(size: 8, weight: .regular))
+                            .foregroundColor(.white.opacity(0.5))
+                            .lineLimit(1)
                     }
                 }
                 .padding(.leading, 12)


### PR DESCRIPTION
Closes #23

## Summary

Promotes `event.project` to the primary identity in both notch ears and the capsule pill, demoting the action ("Reading" / "Permission" / …) to a small accent. Multi-session users read "which session is pinging me" before "what is it doing".

## What this PR does

- **`feat(capsule): promote project to primary title`** — `CompactPillView` and `ExpandedPillView`: when `event.project` is set, render it as the primary title (13 pt / 14 pt bold). `event.title` becomes a small accent chip coloured with `event.style.color` on a 0.18 tinted background (claude-orange "Reading" chip, blue "Permission" chip, etc.). `event.subtitle` keeps its second line, no longer prefixed with the project. Falls back to today's layout when no project is set.

- **`feat(notch): promote project to ear title`** — `LeftEarView` / `RightEarView`: swap the two text rows. `event.project` → 11 pt primary; `event.title` → 8 pt sublabel. Drops the small source dot next to the project (the outer-edge stripe already signals source — dot was redundant). Stripe untouched.

Mechanically the two commits are independent (touch different views), but they're paired here for visual parity — a multi-session user often sees both layouts in one workflow.

## Test plan

- [x] `swift build` clean, 88 tests pass
- [x] Capsule with `event.project` set: project is title, action is chip, subtitle on second line
- [x] Capsule without `event.project`: original layout (title = `event.title`)
- [x] Notch with `event.project`: project is 11 pt primary, title is 8 pt sublabel
- [x] Notch without `event.project`: original layout
- [x] Source stripe still visible on both ears
