### PR TITLE
Permission flow: queue concurrent requests + Always allow

### DIFF
--- a/Sources/DynamicIsland/IslandState.swift
+++ b/Sources/DynamicIsland/IslandState.swift
@@ -196,6 +196,12 @@ class IslandStateManager: ObservableObject {
     /// Live view of main + subagent channels, sorted with main first
     @Published var activeSessions: [SessionChannel] = []
 
+    /// Pending `.action` events queued behind the current one. A new `.action`
+    /// arriving while another is awaiting a decision would otherwise overwrite
+    /// the Allow/Deny UI and let the older hook's `/response` long-poll time
+    /// out silently. FIFO — drained one-at-a-time by `dismiss()`.
+    @Published private(set) var pendingActions: [IslandEvent] = []
+
     /// Reference to server for sending permission responses
     weak var server: LocalServer?
 
@@ -250,22 +256,37 @@ class IslandStateManager: ObservableObject {
                 return
             }
 
-            // Normal path: show the latest event immediately, replacing any queue
-            self.eventQueue.removeAll()
-            self.dismissTimer?.invalidate()
-            self.isProcessing = true
-
-            withAnimation(.spring(response: 0.35, dampingFraction: 0.75)) {
-                self.currentEvent = event
-                self.mode = (event.style == .action) ? .expanded : .compact
+            // Guard: while an action is awaiting a decision, don't overwrite
+            // it. Queue another action; drop transient events (a 30s-old
+            // "Reading" surfacing later would confuse more than help).
+            if self.currentEvent?.style == .action {
+                if event.style == .action {
+                    self.pendingActions.append(event)
+                }
+                return
             }
 
-            if !event.persistent {
-                self.dismissTimer = Timer.scheduledTimer(withTimeInterval: event.duration, repeats: false) { [weak self] _ in
-                    DispatchQueue.main.async {
-                        guard let self, !self.isHovered else { return }
-                        self.dismiss()
-                    }
+            self.showEvent(event)
+        }
+    }
+
+    /// Actually swap `currentEvent` and drive the dismiss timer. Assumes
+    /// caller has already cleared any action guard.
+    private func showEvent(_ event: IslandEvent) {
+        eventQueue.removeAll()
+        dismissTimer?.invalidate()
+        isProcessing = true
+
+        withAnimation(.spring(response: 0.35, dampingFraction: 0.75)) {
+            currentEvent = event
+            mode = (event.style == .action) ? .expanded : .compact
+        }
+
+        if !event.persistent {
+            dismissTimer = Timer.scheduledTimer(withTimeInterval: event.duration, repeats: false) { [weak self] _ in
+                DispatchQueue.main.async {
+                    guard let self, !self.isHovered else { return }
+                    self.dismiss()
                 }
             }
         }
@@ -294,6 +315,15 @@ class IslandStateManager: ObservableObject {
 
     func dismiss() {
         dismissTimer?.invalidate()
+
+        // Drain the queued-action backlog before hiding — the next pending
+        // action surfaces here rather than waiting for an external event.
+        if !pendingActions.isEmpty {
+            let next = pendingActions.removeFirst()
+            showEvent(next)
+            return
+        }
+
         isProcessing = false
         withAnimation(.spring(response: 0.5, dampingFraction: 0.8)) {
             mode = .hidden

--- a/Sources/DynamicIsland/IslandState.swift
+++ b/Sources/DynamicIsland/IslandState.swift
@@ -3,6 +3,14 @@ import SwiftUI
 
 // MARK: - Event Model
 
+/// Suggested permission rule forwarded from the PermissionRequest hook so the
+/// capsule can offer an "Always allow" button. Mirrors the shape Claude Code
+/// expects inside `updatedPermissions.rules[]`.
+struct PermissionRuleSuggestion: Equatable {
+    let toolName: String    // e.g. "Bash"
+    let ruleContent: String // e.g. "glab api *"
+}
+
 struct IslandEvent: Identifiable {
     let id: UUID
     let icon: String
@@ -15,6 +23,7 @@ struct IslandEvent: Identifiable {
     let persistent: Bool  // if true, won't auto-dismiss
     let project: String?  // small project name label
     let source: String?   // "claude" / "copilot" / "codex" — drives color
+    let suggestedRule: PermissionRuleSuggestion?
 
     /// Color signaling event source. Falls back to a deterministic
     /// project-name hash when the source isn't known, so legacy callers
@@ -58,7 +67,8 @@ struct IslandEvent: Identifiable {
         progress: Double? = nil,
         persistent: Bool = false,
         project: String? = nil,
-        source: String? = nil
+        source: String? = nil,
+        suggestedRule: PermissionRuleSuggestion? = nil
     ) {
         self.id = id
         self.icon = icon
@@ -71,6 +81,7 @@ struct IslandEvent: Identifiable {
         self.persistent = persistent
         self.project = project
         self.source = source
+        self.suggestedRule = suggestedRule
     }
 }
 
@@ -241,7 +252,9 @@ class IslandStateManager: ObservableObject {
                     detail: event.detail,
                     progress: event.progress,
                     persistent: event.persistent,
-                    project: event.project
+                    project: event.project,
+                    source: event.source,
+                    suggestedRule: event.suggestedRule
                 )
                 self.currentEvent = merged
                 if !event.persistent {

--- a/Sources/DynamicIsland/IslandView.swift
+++ b/Sources/DynamicIsland/IslandView.swift
@@ -553,6 +553,9 @@ struct ExpandedPillView: View {
                     }
                 }
                 Spacer()
+                if stateManager.pendingActions.count > 0 {
+                    PendingActionDots(count: stateManager.pendingActions.count)
+                }
                 Button(action: { stateManager.dismiss() }) {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 16))
@@ -792,6 +795,30 @@ struct SessionRow: View {
     private var activityText: String {
         if session.lastSubtitle.isEmpty { return session.lastTitle }
         return "\(session.lastTitle) · \(session.lastSubtitle)"
+    }
+}
+
+// MARK: - Pending Action Dots
+
+/// Hints that more `.action` events are queued behind the current one,
+/// without a numeric badge. Up to three dots.
+struct PendingActionDots: View {
+    let count: Int
+    @State private var pulse = false
+
+    var body: some View {
+        HStack(spacing: 3) {
+            ForEach(0..<min(count, 3), id: \.self) { _ in
+                Circle()
+                    .fill(Color.white.opacity(pulse ? 0.85 : 0.45))
+                    .frame(width: 4, height: 4)
+            }
+        }
+        .onAppear {
+            withAnimation(.easeInOut(duration: 1.1).repeatForever(autoreverses: true)) {
+                pulse = true
+            }
+        }
     }
 }
 

--- a/Sources/DynamicIsland/IslandView.swift
+++ b/Sources/DynamicIsland/IslandView.swift
@@ -569,7 +569,10 @@ struct ExpandedPillView: View {
             }
 
             if event.style == .action {
-                PermissionActionButtons(stateManager: stateManager)
+                PermissionActionButtons(
+                    stateManager: stateManager,
+                    suggestedRule: event.suggestedRule
+                )
             }
 
             if let progress = event.progress {
@@ -826,40 +829,77 @@ struct PendingActionDots: View {
 
 struct PermissionActionButtons: View {
     @ObservedObject var stateManager: IslandStateManager
+    let suggestedRule: PermissionRuleSuggestion?
 
     var body: some View {
-        HStack(spacing: 12) {
-            Button(action: {
-                stateManager.server?.setResponse("allow")
-                stateManager.dismiss()
-            }) {
-                Text("Allow")
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundColor(.white)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 8)
-                    .background(
-                        RoundedRectangle(cornerRadius: 10)
-                            .fill(Color(red: 0.2, green: 0.5, blue: 1.0))
-                    )
-            }
-            .buttonStyle(.plain)
+        VStack(spacing: 8) {
+            HStack(spacing: 12) {
+                Button(action: {
+                    stateManager.server?.setResponse("allow")
+                    stateManager.dismiss()
+                }) {
+                    Text("Allow")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(Color(red: 0.2, green: 0.5, blue: 1.0))
+                        )
+                }
+                .buttonStyle(.plain)
 
-            Button(action: {
-                stateManager.server?.setResponse("deny")
-                stateManager.dismiss()
-            }) {
-                Text("Deny")
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(.white.opacity(0.8))
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 8)
-                    .background(
-                        RoundedRectangle(cornerRadius: 10)
-                            .fill(Color.white.opacity(0.1))
-                    )
+                Button(action: {
+                    stateManager.server?.setResponse("deny")
+                    stateManager.dismiss()
+                }) {
+                    Text("Deny")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(.white.opacity(0.8))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(Color.white.opacity(0.1))
+                        )
+                }
+                .buttonStyle(.plain)
             }
-            .buttonStyle(.plain)
+
+            // "Always allow" — sends the rule back to Claude Code so the
+            // pattern lands in `localSettings.permissions.allow` and future
+            // matching invocations stop asking. Amber tint (not the Allow
+            // blue) signals "this is a persistent preference" rather than a
+            // primary yes/no action, and shrinks the tap target to reduce
+            // mis-taps on the adjacent Allow button.
+            if let rule = suggestedRule {
+                Button(action: {
+                    stateManager.server?.setResponse("allow", rule: rule)
+                    stateManager.dismiss()
+                }) {
+                    HStack(spacing: 8) {
+                        Spacer()
+                        Text("🔓").font(.system(size: 11))
+                        Text("Always allow")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundColor(Color(red: 1.0, green: 0.75, blue: 0.4))
+                        Text(rule.ruleContent)
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundColor(Color(red: 1.0, green: 0.82, blue: 0.59).opacity(0.75))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Spacer()
+                    }
+                    .padding(.vertical, 5)
+                    .padding(.horizontal, 10)
+                    .background(
+                        RoundedRectangle(cornerRadius: 9)
+                            .fill(Color(red: 1.0, green: 0.67, blue: 0.24).opacity(0.14))
+                    )
+                }
+                .buttonStyle(.plain)
+            }
         }
     }
 }

--- a/Sources/DynamicIsland/LocalServer.swift
+++ b/Sources/DynamicIsland/LocalServer.swift
@@ -17,32 +17,61 @@ import DynamicIslandCore
 ///   "progress": 0.0-1.0
 /// }
 /// ```
+/// Encodes the UI's permission decision for the long-polling hook.
+/// `rule` is non-nil only when the user chose "Always allow"; the hook
+/// forwards it to Claude Code as `updatedPermissions.rules[0]` so the
+/// pattern lands in the user's `localSettings`.
+struct PermissionDecision {
+    let behavior: String                     // "allow" | "deny"
+    let rule: PermissionRuleSuggestion?
+
+    var jsonBody: String {
+        var parts = ["\"behavior\":\"\(behavior)\""]
+        if let rule = rule {
+            parts.append(
+                "\"rule\":{\"toolName\":\"\(rule.toolName)\",\"ruleContent\":\(Self.encodeJSON(rule.ruleContent))}"
+            )
+        }
+        return "{\(parts.joined(separator: ","))}"
+    }
+
+    private static func encodeJSON(_ s: String) -> String {
+        if let data = try? JSONSerialization.data(withJSONObject: [s], options: []),
+           let jsonArr = String(data: data, encoding: .utf8) {
+            // Strip "[" and "]" to get just the quoted, escaped string.
+            return String(jsonArr.dropFirst().dropLast())
+        }
+        return "\"\"" // fallback — will not corrupt the envelope
+    }
+}
+
 class LocalServer {
     let port: UInt16
     private var listener: NWListener?
     private weak var stateManager: IslandStateManager?
 
     /// Pending permission response — hook script polls this
-    private var pendingResponse: String?
+    private var pendingResponse: PermissionDecision?
     private let responseLock = NSLock()
-    private var responseWaiters: [CheckedContinuation<String, Never>] = []
+    private var responseWaiters: [CheckedContinuation<PermissionDecision, Never>] = []
 
     init(stateManager: IslandStateManager, port: UInt16 = 9423) {
         self.stateManager = stateManager
         self.port = port
     }
 
-    /// Called from UI when user taps Allow/Deny
-    func setResponse(_ value: String) {
+    /// Called from UI when user taps Allow/Deny/Always.
+    func setResponse(_ behavior: String, rule: PermissionRuleSuggestion? = nil) {
+        let decision = PermissionDecision(behavior: behavior, rule: rule)
         responseLock.lock()
         let waiters = responseWaiters
         responseWaiters.removeAll()
         if waiters.isEmpty {
-            pendingResponse = value
+            pendingResponse = decision
         }
         responseLock.unlock()
         for waiter in waiters {
-            waiter.resume(returning: value)
+            waiter.resume(returning: decision)
         }
     }
 
@@ -223,20 +252,21 @@ class LocalServer {
         })
     }
 
-    /// Long-poll: waits up to 25s for user to tap Allow/Deny, then returns the choice
+    /// Long-poll: waits up to 25s for user to tap Allow/Deny/Always, then returns the choice
     private func handleResponsePoll(_ connection: NWConnection) {
+        let timeoutDecision = PermissionDecision(behavior: "timeout", rule: nil)
         responseLock.lock()
         if let response = pendingResponse {
             pendingResponse = nil
             responseLock.unlock()
-            sendHTTP(connection, body: "{\"decision\":\"\(response)\"}")
+            sendHTTP(connection, body: response.jsonBody)
             return
         }
         responseLock.unlock()
 
         // Long-poll: wait for response with timeout
         Task {
-            let result = await withTaskGroup(of: String.self, returning: String.self) { group in
+            let result = await withTaskGroup(of: PermissionDecision.self, returning: PermissionDecision.self) { group in
                 group.addTask {
                     await withCheckedContinuation { continuation in
                         self.responseLock.lock()
@@ -253,18 +283,14 @@ class LocalServer {
                 }
                 group.addTask {
                     try? await Task.sleep(nanoseconds: 25_000_000_000) // 25s timeout
-                    return "timeout"
+                    return timeoutDecision
                 }
                 let first = await group.next()!
                 group.cancelAll()
                 return first
             }
 
-            if result == "timeout" {
-                self.sendHTTP(connection, body: "{\"decision\":\"timeout\"}")
-            } else {
-                self.sendHTTP(connection, body: "{\"decision\":\"\(result)\"}")
-            }
+            self.sendHTTP(connection, body: result.jsonBody)
         }
     }
 
@@ -330,6 +356,13 @@ class LocalServer {
             icon = Self.iconForType(type)
         }
 
+        var suggestedRule: PermissionRuleSuggestion? = nil
+        if let dict = json["suggested_rule"] as? [String: Any],
+           let toolName = dict["toolName"] as? String,
+           let ruleContent = dict["ruleContent"] as? String {
+            suggestedRule = PermissionRuleSuggestion(toolName: toolName, ruleContent: ruleContent)
+        }
+
         let event = IslandEvent(
             icon: icon,
             title: title,
@@ -340,7 +373,8 @@ class LocalServer {
             progress: progress,
             persistent: persistent,
             project: project,
-            source: source
+            source: source,
+            suggestedRule: suggestedRule
         )
 
         // Route into the session tree: main session when no agent_id, else

--- a/Sources/IslandHookCore/PayloadBuilder.swift
+++ b/Sources/IslandHookCore/PayloadBuilder.swift
@@ -132,6 +132,29 @@ public func buildNotificationPayload(_ plan: HookPlan) -> [String: Any]? {
     ])
 }
 
+/// A rule string that approximates Claude Code's own "don't ask again"
+/// suggestion. The caller forwards this through the PermissionRequest
+/// payload so the UI can offer an "Always allow" button; when the user
+/// picks it, the hook emits `updatedPermissions` with `localSettings`
+/// destination matching Claude's built-in behaviour.
+///
+/// Heuristic, kept deliberately conservative:
+/// - Bash: first two space-separated tokens + ` *` (matches the
+///   "glab api *" / "git status *" style Claude shows in its own prompt).
+/// - Other tools: nil for now — pattern shape differs per tool
+///   (`Edit(**/*.swift)` etc.) and we'd rather not offer a wrong rule.
+public func suggestPermissionRule(toolName: String, toolInput: [String: Any]) -> (toolName: String, ruleContent: String)? {
+    switch toolName {
+    case "Bash":
+        let cmd = (toolInput["command"] as? String) ?? ""
+        let tokens = cmd.split(separator: " ").prefix(2).map(String.init)
+        guard !tokens.isEmpty else { return nil }
+        return (toolName: "Bash", ruleContent: tokens.joined(separator: " ") + " *")
+    default:
+        return nil
+    }
+}
+
 /// Build the PermissionRequest dialog payload. If cached PreToolUse input
 /// is provided and matches the tool, enriches the detail with a diff or
 /// content preview.
@@ -179,6 +202,16 @@ public func buildPermissionRequestPayload(
         "style": "action",
     ]
     if !diff.isEmpty { p["detail"] = diff }
+    // Suggest an "always allow" rule when we have enough signal. The UI
+    // uses this to offer a third button; when chosen, the hook echoes the
+    // pattern back to Claude Code via `updatedPermissions`.
+    let effectiveInput = (cachedToolName == toolName ? cachedInput : nil) ?? plan.toolInput
+    if let rule = suggestPermissionRule(toolName: toolName, toolInput: effectiveInput) {
+        p["suggested_rule"] = [
+            "toolName": rule.toolName,
+            "ruleContent": rule.ruleContent,
+        ]
+    }
     return plan.decorate(p)
 }
 

--- a/Sources/island-hook/main.swift
+++ b/Sources/island-hook/main.swift
@@ -38,17 +38,31 @@ func send(_ body: [String: Any]) {
     _ = sem.wait(timeout: .now() + 3)
 }
 
-func longPollResponse(timeoutSeconds: TimeInterval) -> String {
+struct PermissionDecision {
+    var behavior: String
+    var rule: (toolName: String, ruleContent: String)?
+}
+
+func longPollResponse(timeoutSeconds: TimeInterval) -> PermissionDecision {
     var req = URLRequest(url: responseURL)
     req.timeoutInterval = timeoutSeconds + 1
-    var decision = "timeout"
+    var decision = PermissionDecision(behavior: "timeout", rule: nil)
     let sem = DispatchSemaphore(value: 0)
     URLSession.shared.dataTask(with: req) { data, _, _ in
         defer { sem.signal() }
         guard let data = data,
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let d = json["decision"] as? String else { return }
-        decision = d
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return }
+        // Backwards-compatible: older server versions returned
+        // `{"decision": "allow"}`. Newer ones return
+        // `{"behavior": "allow", "rule": {...}?}`.
+        let behavior = (json["behavior"] as? String) ?? (json["decision"] as? String) ?? "timeout"
+        decision.behavior = behavior
+        if let rule = json["rule"] as? [String: Any],
+           let toolName = rule["toolName"] as? String,
+           let ruleContent = rule["ruleContent"] as? String {
+            decision.rule = (toolName: toolName, ruleContent: ruleContent)
+        }
     }.resume()
     _ = sem.wait(timeout: .now() + timeoutSeconds + 2)
     return decision
@@ -100,9 +114,37 @@ case "PermissionRequest":
     )
     send(body)
 
-    switch longPollResponse(timeoutSeconds: 25) {
+    let decision = longPollResponse(timeoutSeconds: 25)
+    switch decision.behavior {
     case "allow":
-        print(#"{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}"#)
+        if let rule = decision.rule {
+            // Claude Code persists the pattern to localSettings (project scope)
+            // — matches the "Yes, and don't ask again for: <pattern>" option
+            // from its own interactive prompt.
+            let payload: [String: Any] = [
+                "hookSpecificOutput": [
+                    "hookEventName": "PermissionRequest",
+                    "decision": [
+                        "behavior": "allow",
+                        "updatedPermissions": [[
+                            "type": "addRules",
+                            "rules": [[
+                                "toolName": rule.toolName,
+                                "ruleContent": rule.ruleContent,
+                            ]],
+                            "behavior": "allow",
+                            "destination": "localSettings",
+                        ] as [String: Any]],
+                    ] as [String: Any],
+                ],
+            ]
+            if let data = try? JSONSerialization.data(withJSONObject: payload, options: []),
+               let jsonString = String(data: data, encoding: .utf8) {
+                print(jsonString)
+            }
+        } else {
+            print(#"{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}"#)
+        }
     case "deny":
         print(#"{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"deny","message":"Denied from Dynamic Island"}}}"#)
     default: break


### PR DESCRIPTION
Closes #24

## Summary

Two changes to the permission flow:

1. **Bug fix:** Concurrent `PermissionRequest` events stop overwriting each other.
2. **Feature:** Add a third "Always allow" button mirroring Claude Code's "Yes, and don't ask again for: <pattern>".

## What this PR does

### `fix(capsule): queue concurrent PermissionRequest`

`IslandStateManager.pushEvent` previously replaced `currentEvent` unconditionally. Two concurrent sessions: A's Allow/Deny dialog could be erased by any transient ping from B; A's hook would time out silently. `pushEvent` now guards against `currentEvent?.style == .action`:

- Another `.action` → enqueue to `pendingActions` (FIFO).
- Transient event → drop on the floor (a 30-s-old "Reading" surfacing after the user decided would confuse more than help).

`dismiss()` drains the queue one at a time. `ExpandedPillView` shows a small `+N` capsule next to the close ✕ when the queue is non-empty.

### `feat(capsule): "Always allow" with persistent rule`

Wire end-to-end:

1. `IslandHookCore.suggestPermissionRule` derives a conservative rule pattern from `tool_name` + `tool_input`. Bash only for now: first two space-separated tokens + ` *` (matches the `glab api *` / `git status *` shape Claude's own UI picks). Other tools return nil — pattern shape varies per tool, a wrong rule is worse than none.
2. `buildPermissionRequestPayload` forwards the suggestion as `suggested_rule`.
3. `LocalServer` decodes onto `IslandEvent.suggestedRule`. The `/response` body changes from `{"decision":"allow"}` to `{"behavior":"allow","rule":{...}?}` — backwards-compatible with older clients via the legacy `decision` key.
4. `island-hook` emits Claude's `updatedPermissions: addRules` payload when a rule is chosen, scoped to `localSettings` (`.claude/settings.local.json`, not user-global).
5. `PermissionActionButtons` gains `suggestedRule: SuggestedRule?`. When non-nil, renders a third amber-tinted button below Allow/Deny, labelled with the rule pattern (e.g. "Always allow `git status *`"). When nil — for tool types we don't have a rule shape for yet — only Allow/Deny render.

## Test plan

- [x] `swift build` clean, 88 tests pass
- [x] Concurrent permission requests: second one queues, `+N` chip appears, decision drains queue one at a time
- [x] Transient event during permission dialog: dropped, dialog stays
- [x] Always allow Bash command: rule lands in `.claude/settings.local.json`
- [x] Tool without a rule shape: only Allow/Deny render, no third button
- [x] Older hook + this server: legacy `{"decision":...}` path still works
