### PR TITLE
feat(stop-reply): quick-reply buttons for yes/no Stop events (#20 Phase 1)

### DIFF
--- a/Sources/DynamicIsland/IslandState.swift
+++ b/Sources/DynamicIsland/IslandState.swift
@@ -24,6 +24,13 @@ struct IslandEvent: Identifiable {
     let project: String?  // small project name label
     let source: String?   // "claude" / "copilot" / "codex" — drives color
     let suggestedRule: PermissionRuleSuggestion?
+    /// Phase 1 of #20 (Stop reply quick-reply buttons). Non-nil for Stop
+    /// events with a recognised yes/no shape — the strings render as
+    /// labelled buttons; tapping one POSTs to /response and the hook
+    /// emits `decision:block + reason:<label>`. Nil for events without a
+    /// known reply shape; Phase 2 will add a free-form text field for
+    /// those cases.
+    let quickReplies: [String]?
 
     /// Color signaling event source. Falls back to a deterministic
     /// project-name hash when the source isn't known, so legacy callers
@@ -68,7 +75,8 @@ struct IslandEvent: Identifiable {
         persistent: Bool = false,
         project: String? = nil,
         source: String? = nil,
-        suggestedRule: PermissionRuleSuggestion? = nil
+        suggestedRule: PermissionRuleSuggestion? = nil,
+        quickReplies: [String]? = nil
     ) {
         self.id = id
         self.icon = icon
@@ -82,6 +90,7 @@ struct IslandEvent: Identifiable {
         self.project = project
         self.source = source
         self.suggestedRule = suggestedRule
+        self.quickReplies = quickReplies
     }
 }
 
@@ -274,11 +283,20 @@ class IslandStateManager: ObservableObject {
                 return
             }
 
-            // Guard: while an action is awaiting a decision, don't overwrite
-            // it. Queue another action; drop transient events (a 30s-old
-            // "Reading" surfacing later would confuse more than help).
-            if self.currentEvent?.style == .action {
-                if event.style == .action {
+            // Guard: while the user is mid-decision, don't overwrite. Two
+            // shapes count as "mid-decision":
+            //   - .action with Allow/Deny (#28's PermissionRequest)
+            //   - .reminder with quick-reply buttons (#20 Phase 1 Stop reply)
+            // Both have a hook waiting on `/response`; clobbering the event
+            // strands the hook in a 25-30 s timeout. Queue another such
+            // event; drop transient pings.
+            let inDecision = self.currentEvent?.style == .action
+                || (self.currentEvent?.style == .reminder
+                    && self.currentEvent?.quickReplies != nil)
+            if inDecision {
+                let isDecisionEvent = event.style == .action
+                    || (event.style == .reminder && event.quickReplies != nil)
+                if isDecisionEvent {
                     self.pendingActions.append(event)
                 }
                 return
@@ -295,9 +313,13 @@ class IslandStateManager: ObservableObject {
         dismissTimer?.invalidate()
         isProcessing = true
 
+        // Action events and quick-reply reminders open expanded so the
+        // user can see the decision buttons immediately. Other events
+        // start compact and grow if the user clicks.
+        let needsExpanded = event.style == .action || event.quickReplies != nil
         withAnimation(.spring(response: 0.35, dampingFraction: 0.75)) {
             currentEvent = event
-            mode = (event.style == .action) ? .expanded : .compact
+            mode = needsExpanded ? .expanded : .compact
         }
 
         if !event.persistent {

--- a/Sources/DynamicIsland/IslandView.swift
+++ b/Sources/DynamicIsland/IslandView.swift
@@ -383,7 +383,11 @@ struct ExpandedContentView: View {
             // Detail — renders as a colored diff when lines start with "+ " / "- ",
             // otherwise falls back to plain monospaced text
             if let detail = event.detail {
-                DiffDetailView(text: detail)
+                // Decision events (Allow/Deny or quick reply) need the full
+                // context to choose — let the detail scroll. Observational
+                // events keep notch's truncated default for visual density.
+                let needsFullContext = event.style == .action || event.quickReplies != nil
+                DiffDetailView(text: detail, scrollable: needsFullContext)
             }
 
             if event.style == .action {

--- a/Sources/DynamicIsland/IslandView.swift
+++ b/Sources/DynamicIsland/IslandView.swift
@@ -393,6 +393,10 @@ struct ExpandedContentView: View {
                 )
             }
 
+            if let labels = event.quickReplies {
+                QuickReplyButtons(stateManager: stateManager, labels: labels)
+            }
+
             if let progress = event.progress {
                 LinearProgressBar(progress: progress, color: event.style.color)
             }
@@ -415,7 +419,13 @@ struct ExpandedContentView: View {
                 )
                 .shadow(color: event.style.glowColor, radius: 10, y: 4)
         )
-        .onTapGesture { stateManager.collapse() }
+        .onTapGesture {
+            // Don't collapse while the user is mid-decision: action events
+            // (Allow/Deny) and reminders with quick-reply buttons. Collapsing
+            // sets a 2 s dismiss timer that strands the long-polling hook.
+            if event.style == .action || event.quickReplies != nil { return }
+            stateManager.collapse()
+        }
     }
 }
 
@@ -570,6 +580,10 @@ struct ExpandedPillView: View {
                 )
             }
 
+            if let labels = event.quickReplies {
+                QuickReplyButtons(stateManager: stateManager, labels: labels)
+            }
+
             if let progress = event.progress {
                 LinearProgressBar(progress: progress, color: event.style.color)
             }
@@ -596,8 +610,10 @@ struct ExpandedPillView: View {
                 )
         )
         .onTapGesture {
-            // Don't collapse on action — the user must pick Allow or Deny.
-            if event.style == .action { return }
+            // Don't collapse while the user is mid-decision: action events
+            // (Allow/Deny) and reminders with quick-reply buttons. Collapsing
+            // sets a 2 s dismiss timer that strands the long-polling hook.
+            if event.style == .action || event.quickReplies != nil { return }
             stateManager.collapse()
         }
         .onAppear { updateActionPulse() }
@@ -957,6 +973,43 @@ struct PermissionActionButtons: View {
                         RoundedRectangle(cornerRadius: 9)
                             .fill(Color(red: 1.0, green: 0.67, blue: 0.24).opacity(0.14))
                     )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}
+
+// MARK: - Quick Reply Buttons (shared by notch + capsule expanded)
+
+/// Phase 1 of #20. Renders one button per `labels` entry; tap POSTs the
+/// label as the response body to the long-polling Stop hook, which then
+/// emits `decision:block + reason:<label>` to Claude. Layout and tinting
+/// mirror `PermissionActionButtons` so the two buttons rows feel
+/// consistent across action and reminder events.
+///
+/// Caller is expected to cap `labels` at 3 entries / 20 chars each
+/// (enforced server-side in `LocalServer.processEvent` already).
+struct QuickReplyButtons: View {
+    @ObservedObject var stateManager: IslandStateManager
+    let labels: [String]
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ForEach(labels, id: \.self) { label in
+                Button(action: {
+                    stateManager.server?.setResponse(label)
+                    stateManager.dismiss()
+                }) {
+                    Text(label)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(.white.opacity(0.95))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(Color.white.opacity(0.12))
+                        )
                 }
                 .buttonStyle(.plain)
             }

--- a/Sources/DynamicIsland/LocalServer.swift
+++ b/Sources/DynamicIsland/LocalServer.swift
@@ -363,6 +363,21 @@ class LocalServer {
             suggestedRule = PermissionRuleSuggestion(toolName: toolName, ruleContent: ruleContent)
         }
 
+        // #20 Phase 1: quick-reply button labels. Cap at 3 entries / 20
+        // chars per label so the button row fits whichever expanded view
+        // renders it (notch ~445 pt, capsule 420 pt). Non-string entries
+        // are dropped silently.
+        var quickReplies: [String]? = nil
+        if let raw = json["quick_replies"] as? [Any] {
+            let labels = raw
+                .compactMap { $0 as? String }
+                .map { String($0.prefix(20)) }
+                .prefix(3)
+            if !labels.isEmpty {
+                quickReplies = Array(labels)
+            }
+        }
+
         let event = IslandEvent(
             icon: icon,
             title: title,
@@ -374,7 +389,8 @@ class LocalServer {
             persistent: persistent,
             project: project,
             source: source,
-            suggestedRule: suggestedRule
+            suggestedRule: suggestedRule,
+            quickReplies: quickReplies
         )
 
         // Route into the session tree: main session when no agent_id, else

--- a/Sources/IslandHookCore/PayloadBuilder.swift
+++ b/Sources/IslandHookCore/PayloadBuilder.swift
@@ -217,8 +217,7 @@ public func buildPermissionRequestPayload(
 
 public func buildStopPayload(_ plan: HookPlan) -> [String: Any] {
     let lastMsg = (plan.payload["last_assistant_message"] as? String) ?? ""
-    let tail = String(lastMsg.suffix(200))
-    if tail.range(of: #"[?？]\s*$"#, options: .regularExpression) != nil {
+    if containsQuestion(lastMsg) {
         let question = extractLastQuestion(from: lastMsg)
         var p: [String: Any] = [
             "title": "Waiting",
@@ -226,6 +225,13 @@ public func buildStopPayload(_ plan: HookPlan) -> [String: Any] {
             "style": "reminder",
         ]
         if !lastMsg.isEmpty { p["detail"] = lastMsg }
+        // Phase 1 of #20: when we recognise a yes/no shape, surface
+        // quick-reply buttons. Reading the buttons in island-hook decides
+        // whether to long-poll for a reply and emit `decision:block`.
+        if let options = extractYesNoOptions(from: lastMsg) {
+            p["quick_replies"] = options
+            p["persistent"] = true
+        }
         return plan.decorate(p)
     } else {
         return plan.decorate([

--- a/Sources/IslandHookCore/StopReply.swift
+++ b/Sources/IslandHookCore/StopReply.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// How long the Stop hook waits for a reply via the long-poll `/response`
+/// endpoint before falling back to Claude Code's default Stop behavior.
+/// Issue #20 marks 30 s as a first guess — short enough that Claude Code's
+/// internal flow doesn't stall, long enough that a user who briefly tabs
+/// away can still react. Tunable as user feedback rolls in.
+public let StopReplyTimeoutSeconds: TimeInterval = 30
+
+/// Returns true if `message` contains a `?` or `？` anywhere — used to
+/// decide whether a Stop event should offer reply UI (quick-reply buttons
+/// today, inline text field once Phase 2 lands).
+///
+/// Bias toward showing: `extractLastQuestion` (#9 v1.5.0) only catches the
+/// trailing sentence's terminator, missing embedded questions like
+/// "你覺得呢？如果不這樣做的話系統可能會有問題". False positives are 1 second
+/// of "no buttons appeared, dismiss"; false negatives waste Cmd-Tab effort.
+public func containsQuestion(_ message: String) -> Bool {
+    return message.contains("?") || message.contains("？")
+}
+
+/// Detects yes/no patterns in a Stop event message and returns the labels
+/// to render as quick-reply buttons. Returns nil when no patterns match —
+/// callers must NOT synthesise a default `["Yes", "No"]` (a wrong rule is
+/// worse than no rule, mirrors `suggestPermissionRule` from #28).
+///
+/// Recognised patterns:
+///   - `yes/no` (or `no/yes`, fullwidth `／`, any case) → `["Yes", "No"]`
+///   - `y/n` (any case) → `["Yes", "No"]`
+///   - `是/否` (or `否/是`, fullwidth `／`) → `["是", "否"]`
+public func extractYesNoOptions(from message: String) -> [String]? {
+    let opts: NSString.CompareOptions = [.regularExpression, .caseInsensitive]
+
+    if message.range(of: #"\b(yes\s*[/／]\s*no|no\s*[/／]\s*yes)\b"#, options: opts) != nil {
+        return ["Yes", "No"]
+    }
+    if message.range(of: #"\b(y\s*[/／]\s*n|n\s*[/／]\s*y)\b"#, options: opts) != nil {
+        return ["Yes", "No"]
+    }
+    if message.contains("是/否") || message.contains("是／否")
+        || message.contains("否/是") || message.contains("否／是") {
+        return ["是", "否"]
+    }
+    return nil
+}
+
+/// Builds the JSON body the Stop hook prints to stdout when the user
+/// replies through the island. Claude Code receives this as
+/// `decision: "block"` + `reason: "<text>"`, treating `reason` as the
+/// user's next instruction (per the official hooks docs).
+///
+/// `JSONSerialization` is the only contract the hook side relies on —
+/// see `EncodeStopBlockResponseTests` for the round-trip cases (UTF-8 /
+/// emoji / quotes / newlines / 5000-char) that map to the edge cases
+/// xero7689 flagged in issue #20.
+public func encodeStopBlockResponse(reason: String) -> String {
+    let payload: [String: Any] = [
+        "decision": "block",
+        "reason": reason,
+    ]
+    guard let data = try? JSONSerialization.data(
+            withJSONObject: payload,
+            options: [.withoutEscapingSlashes]),
+          let body = String(data: data, encoding: .utf8) else {
+        return #"{"decision":"block","reason":""}"#  // Should never trigger
+    }
+    return body
+}

--- a/Sources/island-hook/main.swift
+++ b/Sources/island-hook/main.swift
@@ -153,7 +153,18 @@ case "PermissionRequest":
 
 case "Stop":
     send(["type": "thinking_stop"])
-    send(buildStopPayload(plan))
+    let stopPayload = buildStopPayload(plan)
+    send(stopPayload)
+    // #20 Phase 1: when the payload offers quick-reply buttons, long-poll
+    // for the user's choice and emit `decision: block + reason: <label>`
+    // so Claude treats the label as the next instruction. Timeout drops
+    // back to Claude Code's default Stop behavior silently.
+    if stopPayload["quick_replies"] is [String] {
+        let decision = longPollResponse(timeoutSeconds: StopReplyTimeoutSeconds)
+        if decision.behavior != "timeout" && !decision.behavior.isEmpty {
+            print(encodeStopBlockResponse(reason: decision.behavior))
+        }
+    }
 
 case "StopFailure":
     send(["type": "thinking_stop"])

--- a/Tests/IslandHookCoreTests/PayloadBuilderTests.swift
+++ b/Tests/IslandHookCoreTests/PayloadBuilderTests.swift
@@ -328,6 +328,63 @@ final class PayloadBuilderTests: XCTestCase {
         XCTAssertEqual(buildStopPayload(p)["title"] as? String, "Waiting")
     }
 
+    // MARK: - Stop with quick reply (issue #20 Phase 1)
+
+    /// xero7689's embedded-question case from #20: question precedes a
+    /// trailing statement. The pre-#20 narrow check (last 200 chars end
+    /// with `?`/`？`) missed this. `containsQuestion` catches it.
+    func testStop_embeddedQuestionThenStatement_emitsWaiting() {
+        let p = plan([
+            "hook_event_name": "Stop",
+            "last_assistant_message": "你覺得呢？如果不這樣做的話系統可能會有問題。",
+            "cwd": "/tmp",
+        ])
+        let body = buildStopPayload(p)
+        XCTAssertEqual(body["title"] as? String, "Waiting")
+        XCTAssertEqual(body["style"] as? String, "reminder")
+    }
+
+    func testStop_yesNoPattern_attachesQuickReplies() {
+        let p = plan([
+            "hook_event_name": "Stop",
+            "last_assistant_message": "Should I commit and push? yes/no",
+            "cwd": "/tmp",
+        ])
+        let body = buildStopPayload(p)
+        XCTAssertEqual(body["quick_replies"] as? [String], ["Yes", "No"])
+        // Persistent so it doesn't auto-dismiss while user decides.
+        XCTAssertEqual(body["persistent"] as? Bool, true)
+    }
+
+    func testStop_chineseYesNoPattern_attachesQuickReplies() {
+        let p = plan([
+            "hook_event_name": "Stop",
+            "last_assistant_message": "繼續執行嗎？是/否",
+            "cwd": "/tmp",
+        ])
+        XCTAssertEqual(buildStopPayload(p)["quick_replies"] as? [String], ["是", "否"])
+    }
+
+    func testStop_questionWithoutPattern_omitsQuickReplies() {
+        let p = plan([
+            "hook_event_name": "Stop",
+            "last_assistant_message": "Should I use option A or B?",
+            "cwd": "/tmp",
+        ])
+        let body = buildStopPayload(p)
+        XCTAssertEqual(body["title"] as? String, "Waiting")
+        XCTAssertNil(body["quick_replies"])
+    }
+
+    func testStop_declarative_omitsQuickReplies() {
+        let p = plan([
+            "hook_event_name": "Stop",
+            "last_assistant_message": "All checks passed.",
+            "cwd": "/tmp",
+        ])
+        XCTAssertNil(buildStopPayload(p)["quick_replies"])
+    }
+
     // MARK: - PermissionRequest with FIFO cache
 
     func testPermissionRequest_EnrichesWithCachedDiff() {

--- a/Tests/IslandHookCoreTests/StopReplyTests.swift
+++ b/Tests/IslandHookCoreTests/StopReplyTests.swift
@@ -1,0 +1,190 @@
+import XCTest
+@testable import IslandHookCore
+
+// MARK: - containsQuestion
+
+final class ContainsQuestionTests: XCTestCase {
+    func test_emptyString_returnsFalse() {
+        XCTAssertFalse(containsQuestion(""))
+    }
+
+    func test_pureStatement_returnsFalse() {
+        XCTAssertFalse(containsQuestion("All checks passed."))
+    }
+
+    func test_trailingASCIIQuestionMark_returnsTrue() {
+        XCTAssertTrue(containsQuestion("Should I proceed?"))
+    }
+
+    func test_trailingFullwidthQuestionMark_returnsTrue() {
+        XCTAssertTrue(containsQuestion("該怎麼辦？"))
+    }
+
+    /// xero7689's specific case from #20 review: question is embedded
+    /// before a trailing statement. `extractLastQuestion` (#9 v1.5.0)
+    /// would miss this because the last sentence isn't terminated by `?`.
+    func test_embeddedQuestionFollowedByStatement_returnsTrue() {
+        XCTAssertTrue(containsQuestion("你覺得呢？如果不這樣做的話系統可能會有問題。"))
+    }
+
+    func test_questionInMiddle_returnsTrue() {
+        XCTAssertTrue(containsQuestion("Earlier I noted X. Should I proceed? Then I continued."))
+    }
+
+    /// Acknowledged false positive — the bias is toward showing reply UI.
+    /// Cost of false positive: one second of "no buttons appeared, dismiss".
+    /// Cost of false negative: the Cmd-Tab pain we're trying to remove.
+    func test_ternaryOperator_returnsTrueAcceptedFalsePositive() {
+        XCTAssertTrue(containsQuestion("Use the ?: operator here."))
+    }
+}
+
+// MARK: - extractYesNoOptions
+
+final class ExtractYesNoOptionsTests: XCTestCase {
+    func test_yesNoSlash_returnsYesNo() {
+        XCTAssertEqual(extractYesNoOptions(from: "Continue? yes/no"), ["Yes", "No"])
+    }
+
+    func test_yesNoSlashUppercase_returnsYesNo() {
+        XCTAssertEqual(extractYesNoOptions(from: "Continue? YES/NO"), ["Yes", "No"])
+    }
+
+    func test_noYesSlash_returnsYesNo() {
+        XCTAssertEqual(extractYesNoOptions(from: "Continue? no/yes"), ["Yes", "No"])
+    }
+
+    func test_yNSlash_returnsYesNo() {
+        XCTAssertEqual(extractYesNoOptions(from: "OK? Y/N"), ["Yes", "No"])
+    }
+
+    func test_yNSlashLowercase_returnsYesNo() {
+        XCTAssertEqual(extractYesNoOptions(from: "OK? y/n"), ["Yes", "No"])
+    }
+
+    func test_fullwidthSlash_returnsYesNo() {
+        XCTAssertEqual(extractYesNoOptions(from: "繼續嗎？yes／no"), ["Yes", "No"])
+    }
+
+    func test_chineseYesNoHalfwidthSlash_returnsChinese() {
+        XCTAssertEqual(extractYesNoOptions(from: "繼續嗎？是/否"), ["是", "否"])
+    }
+
+    func test_chineseYesNoFullwidthSlash_returnsChinese() {
+        XCTAssertEqual(extractYesNoOptions(from: "繼續嗎？是／否"), ["是", "否"])
+    }
+
+    func test_chineseNoYes_returnsChinese() {
+        XCTAssertEqual(extractYesNoOptions(from: "繼續嗎？否/是"), ["是", "否"])
+    }
+
+    func test_AorB_returnsNil() {
+        // "Should I use option A or B?" doesn't follow our recognised
+        // pattern. Returning nil → no buttons, falls back to text field
+        // (Phase 2). Don't synthesise wrong labels.
+        XCTAssertNil(extractYesNoOptions(from: "Should I use option A or B?"))
+    }
+
+    func test_plainQuestion_returnsNil() {
+        XCTAssertNil(extractYesNoOptions(from: "What should I do?"))
+    }
+
+    func test_emptyString_returnsNil() {
+        XCTAssertNil(extractYesNoOptions(from: ""))
+    }
+
+    func test_yesNoAsSeparateWords_returnsNil() {
+        // "yes" and "no" appear but not as the slash-separated pattern.
+        XCTAssertNil(extractYesNoOptions(from: "yes I think no is wrong"))
+    }
+}
+
+// MARK: - encodeStopBlockResponse
+
+final class EncodeStopBlockResponseTests: XCTestCase {
+    /// Round-trip the encoded JSON through JSONSerialization to verify the
+    /// reason survives intact — the only contract that matters for Phase 0.
+    /// Uses `[String: String]` parse since both fields are strings.
+    private func parsedReason(_ encoded: String) -> String? {
+        guard let data = encoded.data(using: .utf8),
+              let dict = try? JSONSerialization.jsonObject(with: data) as? [String: String]
+        else { return nil }
+        return dict["reason"]
+    }
+
+    func test_decisionFieldIsBlock() throws {
+        let encoded = encodeStopBlockResponse(reason: "anything")
+        let data = try XCTUnwrap(encoded.data(using: .utf8))
+        let dict = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: String])
+        XCTAssertEqual(dict["decision"], "block")
+    }
+
+    func test_asciiReason_roundTrips() {
+        XCTAssertEqual(
+            parsedReason(encodeStopBlockResponse(reason: "do this thing")),
+            "do this thing"
+        )
+    }
+
+    func test_chineseReason_roundTrips() {
+        XCTAssertEqual(
+            parsedReason(encodeStopBlockResponse(reason: "請繼續這個任務")),
+            "請繼續這個任務"
+        )
+    }
+
+    func test_emojiReason_roundTrips() {
+        XCTAssertEqual(
+            parsedReason(encodeStopBlockResponse(reason: "🎉🚀 finished")),
+            "🎉🚀 finished"
+        )
+    }
+
+    func test_doubleQuotes_areEscaped() {
+        XCTAssertEqual(
+            parsedReason(encodeStopBlockResponse(reason: #"She said "hi""#)),
+            #"She said "hi""#
+        )
+    }
+
+    func test_newlinesAndTabs_roundTrip() {
+        XCTAssertEqual(
+            parsedReason(encodeStopBlockResponse(reason: "line1\nline2\tcol2")),
+            "line1\nline2\tcol2"
+        )
+    }
+
+    func test_longReason_notTruncated() {
+        let reason = String(repeating: "x", count: 5000)
+        XCTAssertEqual(
+            parsedReason(encodeStopBlockResponse(reason: reason))?.count,
+            5000
+        )
+    }
+
+    func test_emptyReason_roundTrips() {
+        XCTAssertEqual(
+            parsedReason(encodeStopBlockResponse(reason: "")),
+            ""
+        )
+    }
+
+    func test_backslashes_roundTrip() {
+        XCTAssertEqual(
+            parsedReason(encodeStopBlockResponse(reason: #"path\to\file"#)),
+            #"path\to\file"#
+        )
+    }
+}
+
+// MARK: - StopReplyTimeoutSeconds
+
+final class StopReplyTimeoutTests: XCTestCase {
+    /// Sanity floor / ceiling — actual value is a tunable constant. Anything
+    /// outside this range is almost certainly a typo. Real validation comes
+    /// from usage feedback (issue #20 marks 30s as a first guess).
+    func test_constantInReasonableRange() {
+        XCTAssertGreaterThanOrEqual(StopReplyTimeoutSeconds, 10)
+        XCTAssertLessThanOrEqual(StopReplyTimeoutSeconds, 120)
+    }
+}


### PR DESCRIPTION
Phase 1 of #20. End-to-end flow validated against a real Claude session — see test plan below.

## Summary

When Claude ends a turn with a yes/no shaped question, the island now offers tap-to-reply buttons. Click → POST label as response → hook emits `decision: "block" + reason: "<label>"` → Claude takes the label as next instruction. No app switch, no typing.

Replaces RFC v1's larger scope with the slice xero7689 recommended in [#20 review](https://github.com/bistin/cc-island/issues/20#issuecomment-4319974113):
- Quick-reply buttons first (1-click ergonomics), inline text field deferred to Phase 2
- `containsQuestion` replaces the narrow `extractLastQuestion` terminator check (catches embedded questions like `你覺得呢？如果不這樣做的話...`)
- `.reminder + quickReplies` rides #28's queue priority — no new event style

## What this PR does

### `IslandHookCore` — pure logic + 30 tests

New `StopReply.swift`:
- `containsQuestion(_:)` — `?` or `？` anywhere; bias toward showing reply UI. False positives are 1 s "no buttons appeared, dismiss"; false negatives waste Cmd-Tab.
- `extractYesNoOptions(from:)` — recognises `yes/no`, `y/n` (any case, half/fullwidth slash), `是/否`. Returns `nil` when no pattern matches; callers must NOT synthesise default `["Yes","No"]` (mirrors `suggestPermissionRule` from #28 — wrong rule worse than no rule).
- `encodeStopBlockResponse(reason:)` — JSON body the hook prints. Round-trip tests cover the Phase 0 edge cases xero7689 flagged: ASCII / Chinese / emoji / quotes / newlines / 5000-char.
- `StopReplyTimeoutSeconds: TimeInterval = 30` — long-poll horizon, exposed as a tunable constant per [review point 7](https://github.com/bistin/cc-island/issues/20#issuecomment-4319974113).

### Hook (`island-hook/main.swift`)

`Stop` case long-polls `/response` for `StopReplyTimeoutSeconds` when `buildStopPayload` populated `quick_replies`. On reply, prints the encoded `decision:block` JSON; on timeout, exits silently so Claude falls back to its default Stop behavior. `buildStopPayload` adds `quick_replies` (and `persistent: true`) when `extractYesNoOptions` recognises a yes/no shape.

### State (`IslandState`)

- `IslandEvent.quickReplies: [String]?` — non-nil drives button rendering.
- `pushEvent` queue guard extended to also protect `.reminder + quickReplies != nil` events (xero7689's [review point 5](https://github.com/bistin/cc-island/issues/20#issuecomment-4319974113)). Without this, a transient ping from another session could clobber a Stop reply card, stranding the long-polling hook.
- `showEvent` opens directly to `.expanded` when quick replies are present, so buttons are visible immediately.

### UI (`IslandView`)

- New `QuickReplyButtons` shared component, mirrors `PermissionActionButtons` layout. One button per label, full-width split, tap → `setResponse(label)`.
- Wired into both `ExpandedContentView` (notch) and `ExpandedPillView` (capsule).
- Tap-outside-buttons no longer collapses for `.reminder + quickReplies` — same guard `.action` already had, since `collapse()` schedules a 2 s dismiss timer that would strand the hook.
- `DiffDetailView(scrollable:)` opt-in now also fires for notch decision events (action or quickReplies). Long Stop messages were getting `+N more` truncated, but the user needs full context to decide Yes/No. Capsule side already used `scrollable: true` from #19.

### Server (`LocalServer`)

- Decodes incoming `quick_replies: [String]`. Caps at 3 entries, truncates each label to 20 chars (the size envelope agreed in [#20 review point 3](https://github.com/bistin/cc-island/issues/20#issuecomment-4319974113)).
- Reuses existing `setResponse` / `/response` long-poll plumbing — for Stop reply, the `behavior` field carries the user's label (vs `"allow"`/`"deny"` for permissions). Hook side reads it as the reply text.

## Scope — what didn't change

- `extractLastQuestion(_:)` (#9, v1.5.0) is preserved — still drives the `subtitle` text. New `containsQuestion(_:)` only decides whether reply UI is offered.
- Existing `PermissionRequest` flow byte-identical. Same `setResponse` / `/response` endpoints, same `PermissionActionButtons` (now sits next to `QuickReplyButtons` in expanded views).
- Capsule `DiffDetailView` still scrollable from #19 — no behaviour change.
- #26 capsule `ThinkingPillView`, #27 project-as-primary-title, #28 queue + Always-allow rule all intact.

## Test plan

- [x] `swift build` clean; `swift test` 88 → **123 tests, 0 failures** (30 new in `StopReplyTests`, 5 new for `buildStopPayload`'s `quick_replies` branch in `PayloadBuilderTests`)
- [x] **End-to-end smoke test passed against this Claude session.** My turn ended with a message containing `yes/no`; `extractYesNoOptions` matched; quick-reply card rendered with the message + Yes / No buttons; user clicked Yes; hook emitted `{"decision":"block","reason":"Yes"}`; Claude received "Stop hook feedback: Yes" as next user input. Phase 0 (the foundational unknown xero7689 flagged) is verified.
- [x] UTF-8 / quotes / newlines / 5000-char `encodeStopBlockResponse` round-trip via `JSONSerialization` (covered by `EncodeStopBlockResponseTests`).
- [x] Notch `ExpandedContentView` renders quick-reply buttons + scrollable detail; capsule `ExpandedPillView` unchanged behaviorally (already had Allow/Deny pattern from #18).
- [x] tap-outside-buttons no longer collapses `.reminder + quickReplies`; X button still dismisses.
- [ ] Multi-session interaction with #28's queue — not exercised in real concurrent sessions; logically should work since the guard now covers `.reminder + quickReplies` per the same path as `.action`, but worth a real soak.
- [ ] 30 s timeout fallback to Claude Code's default Stop behavior — not explicitly drilled. The hook returns silently on `behavior == "timeout"` and prints nothing, which is the documented contract; no regression expected.

## Out of scope (deferred — see #20 for the longer plan)

- **Phase 2: free-form text field** for questions where `extractYesNoOptions` returns nil. Will reuse the same long-poll path; UI work only. [#20 plan](https://github.com/bistin/cc-island/issues/20).
- **Race fix `setResponse(value, eventID: UUID)`**: late-click after timeout leaks a Stop reply into the next session's `/response` poll. xero7689's [review point 6](https://github.com/bistin/cc-island/issues/20#issuecomment-4319974113) noted this is the same root cause as a permission-side issue worth fixing across both flows. Worth its own PR.
- **Wider pattern recognition**: numbered options, `A or B` extraction, multi-select. Tracked in #20.