### PR TITLE
fix(island): scope long-poll responses by event id; surface expired-state UI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     targets: [
         .executableTarget(
             name: "DynamicIsland",
-            dependencies: ["DynamicIslandCore"],
+            dependencies: ["DynamicIslandCore", "IslandHookCore"],
             path: "Sources/DynamicIsland"
         ),
         // Pure, platform-agnostic helpers extracted from the app so they

--- a/Sources/DynamicIsland/IslandState.swift
+++ b/Sources/DynamicIsland/IslandState.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import IslandHookCore
 
 // MARK: - Event Model
 
@@ -31,6 +32,16 @@ struct IslandEvent: Identifiable {
     /// known reply shape; Phase 2 will add a free-form text field for
     /// those cases.
     let quickReplies: [String]?
+
+    /// Subagent identifier from the hook payload (`agent_id`). Nil for
+    /// main sessions. Used together with `project` to scope same-session
+    /// detection — see `IslandStateManager.pushEvent` (#31 follow-up).
+    let agentID: String?
+
+    /// Claude Code's session UUID from the hook payload, when available.
+    /// Lets us tell two main sessions in the same project apart for the
+    /// same purpose as `agentID`.
+    let sessionID: String?
 
     /// Color signaling event source. Falls back to a deterministic
     /// project-name hash when the source isn't known, so legacy callers
@@ -76,7 +87,9 @@ struct IslandEvent: Identifiable {
         project: String? = nil,
         source: String? = nil,
         suggestedRule: PermissionRuleSuggestion? = nil,
-        quickReplies: [String]? = nil
+        quickReplies: [String]? = nil,
+        agentID: String? = nil,
+        sessionID: String? = nil
     ) {
         self.id = id
         self.icon = icon
@@ -91,6 +104,8 @@ struct IslandEvent: Identifiable {
         self.source = source
         self.suggestedRule = suggestedRule
         self.quickReplies = quickReplies
+        self.agentID = agentID
+        self.sessionID = sessionID
     }
 }
 
@@ -227,6 +242,13 @@ class IslandStateManager: ObservableObject {
     /// out silently. FIFO — drained one-at-a-time by `dismiss()`.
     @Published private(set) var pendingActions: [IslandEvent] = []
 
+    /// Flips to `true` when the current event's hook-side long-poll has
+    /// timed out, so the UI can disable buttons and show a "reply window
+    /// expired" hint instead of silently no-op'ing on a late click (#31).
+    /// Reset on every `showEvent`.
+    @Published private(set) var currentEventExpired: Bool = false
+    private var expirationTimer: Timer?
+
     /// Reference to server for sending permission responses
     weak var server: LocalServer?
 
@@ -289,17 +311,34 @@ class IslandStateManager: ObservableObject {
             //   - .reminder with quick-reply buttons (#20 Phase 1 Stop reply)
             // Both have a hook waiting on `/response`; clobbering the event
             // strands the hook in a 25-30 s timeout. Queue another such
-            // event; drop transient pings.
-            let inDecision = self.currentEvent?.style == .action
-                || (self.currentEvent?.style == .reminder
-                    && self.currentEvent?.quickReplies != nil)
+            // event; drop transient pings from *other* sessions. Once
+            // `currentEventExpired` flips, the hook is gone — release the
+            // lock so any new event can take over instead of leaving a
+            // frozen ghost on screen (#31).
+            let inDecision = !self.currentEventExpired
+                && (self.currentEvent?.style == .action
+                    || (self.currentEvent?.style == .reminder
+                        && self.currentEvent?.quickReplies != nil))
             if inDecision {
                 let isDecisionEvent = event.style == .action
                     || (event.style == .reminder && event.quickReplies != nil)
-                if isDecisionEvent {
+
+                let isSameSession = self.isSameSession(event, as: self.currentEvent)
+
+                // Same-session escape hatch: if the current event came from
+                // session X and a non-decision event from the same session
+                // arrives, the user already answered on the terminal side
+                // (Claude moved on to PreToolUse / PostToolUse). Release the
+                // lock so the new event takes over immediately rather than
+                // waiting out the hook timeout.
+                if !isDecisionEvent && isSameSession {
+                    // fall through to showEvent
+                } else if isDecisionEvent {
                     self.pendingActions.append(event)
+                    return
+                } else {
+                    return // other-session transient: keep protecting
                 }
-                return
             }
 
             self.showEvent(event)
@@ -322,6 +361,31 @@ class IslandStateManager: ObservableObject {
             mode = needsExpanded ? .expanded : .compact
         }
 
+        // Mirror the hook's long-poll horizon so the UI knows when a click
+        // would arrive too late to matter. Disabling the buttons + showing
+        // an "expired" hint is friendlier than a silent no-op (#31).
+        // After a brief read window the pill auto-dismisses so it doesn't
+        // turn into a permanent ghost — the queue guard also releases
+        // (see `pushEvent`) so a new event can take over before then.
+        currentEventExpired = false
+        expirationTimer?.invalidate()
+        if let timeout = expirationTimeout(for: event) {
+            expirationTimer = Timer.scheduledTimer(withTimeInterval: timeout, repeats: false) { [weak self] _ in
+                DispatchQueue.main.async {
+                    guard let self, self.currentEvent?.id == event.id else { return }
+                    self.currentEventExpired = true
+                    // Auto-dismiss after a short read window so the slot
+                    // doesn't stay locked.
+                    Timer.scheduledTimer(withTimeInterval: 5, repeats: false) { [weak self] _ in
+                        DispatchQueue.main.async {
+                            guard let self, self.currentEvent?.id == event.id else { return }
+                            self.dismiss()
+                        }
+                    }
+                }
+            }
+        }
+
         if !event.persistent {
             dismissTimer = Timer.scheduledTimer(withTimeInterval: event.duration, repeats: false) { [weak self] _ in
                 DispatchQueue.main.async {
@@ -330,6 +394,27 @@ class IslandStateManager: ObservableObject {
                 }
             }
         }
+    }
+
+    /// How long until the hook on the other end gives up waiting for a
+    /// reply. Mirrors the hard-coded 25 s in `LocalServer.handleResponsePoll`
+    /// for `.action`, and `IslandHookCore.StopReplyTimeoutSeconds` for the
+    /// quick-reply path. `nil` for events with no decision affordance.
+    private func expirationTimeout(for event: IslandEvent) -> TimeInterval? {
+        if event.style == .action { return 25 }
+        if event.quickReplies != nil { return StopReplyTimeoutSeconds }
+        return nil
+    }
+
+    /// Two events are "same session" when they share Claude's session UUID,
+    /// or when both lack one but agree on (project, agentID). Lets us
+    /// detect that the user resolved a permission/stop prompt on the
+    /// terminal side — the next non-decision event from that session is
+    /// our cue to release the lock and dismiss the stale pill.
+    private func isSameSession(_ a: IslandEvent, as b: IslandEvent?) -> Bool {
+        guard let b else { return false }
+        if let sa = a.sessionID, let sb = b.sessionID { return sa == sb }
+        return a.project == b.project && a.agentID == b.agentID
     }
 
     func expand() {
@@ -355,6 +440,8 @@ class IslandStateManager: ObservableObject {
 
     func dismiss() {
         dismissTimer?.invalidate()
+        expirationTimer?.invalidate()
+        currentEventExpired = false
 
         // Drain the queued-action backlog before hiding — the next pending
         // action surfaces here rather than waiting for an external event.

--- a/Sources/DynamicIsland/IslandView.swift
+++ b/Sources/DynamicIsland/IslandView.swift
@@ -393,12 +393,13 @@ struct ExpandedContentView: View {
             if event.style == .action {
                 PermissionActionButtons(
                     stateManager: stateManager,
-                    suggestedRule: event.suggestedRule
+                    suggestedRule: event.suggestedRule,
+                    eventID: event.id
                 )
             }
 
             if let labels = event.quickReplies {
-                QuickReplyButtons(stateManager: stateManager, labels: labels)
+                QuickReplyButtons(stateManager: stateManager, labels: labels, eventID: event.id)
             }
 
             if let progress = event.progress {
@@ -580,12 +581,13 @@ struct ExpandedPillView: View {
             if event.style == .action {
                 PermissionActionButtons(
                     stateManager: stateManager,
-                    suggestedRule: event.suggestedRule
+                    suggestedRule: event.suggestedRule,
+                    eventID: event.id
                 )
             }
 
             if let labels = event.quickReplies {
-                QuickReplyButtons(stateManager: stateManager, labels: labels)
+                QuickReplyButtons(stateManager: stateManager, labels: labels, eventID: event.id)
             }
 
             if let progress = event.progress {
@@ -910,12 +912,15 @@ struct PendingActionDots: View {
 struct PermissionActionButtons: View {
     @ObservedObject var stateManager: IslandStateManager
     let suggestedRule: PermissionRuleSuggestion?
+    let eventID: UUID
+
+    private var expired: Bool { stateManager.currentEventExpired }
 
     var body: some View {
         VStack(spacing: 8) {
             HStack(spacing: 12) {
                 Button(action: {
-                    stateManager.server?.setResponse("allow")
+                    stateManager.server?.setResponse("allow", eventID: eventID)
                     stateManager.dismiss()
                 }) {
                     Text("Allow")
@@ -929,9 +934,10 @@ struct PermissionActionButtons: View {
                         )
                 }
                 .buttonStyle(.plain)
+                .disabled(expired)
 
                 Button(action: {
-                    stateManager.server?.setResponse("deny")
+                    stateManager.server?.setResponse("deny", eventID: eventID)
                     stateManager.dismiss()
                 }) {
                     Text("Deny")
@@ -945,7 +951,9 @@ struct PermissionActionButtons: View {
                         )
                 }
                 .buttonStyle(.plain)
+                .disabled(expired)
             }
+            .opacity(expired ? 0.5 : 1)
 
             // "Always allow" — sends the rule back to Claude Code so the
             // pattern lands in `localSettings.permissions.allow` and future
@@ -955,7 +963,7 @@ struct PermissionActionButtons: View {
             // mis-taps on the adjacent Allow button.
             if let rule = suggestedRule {
                 Button(action: {
-                    stateManager.server?.setResponse("allow", rule: rule)
+                    stateManager.server?.setResponse("allow", rule: rule, eventID: eventID)
                     stateManager.dismiss()
                 }) {
                     HStack(spacing: 8) {
@@ -979,6 +987,15 @@ struct PermissionActionButtons: View {
                     )
                 }
                 .buttonStyle(.plain)
+                .disabled(expired)
+                .opacity(expired ? 0.5 : 1)
+            }
+
+            if expired {
+                Text("Reply window expired — dismiss and re-trigger to respond.")
+                    .font(.system(size: 10))
+                    .foregroundColor(.white.opacity(0.55))
+                    .frame(maxWidth: .infinity, alignment: .center)
             }
         }
     }
@@ -997,25 +1014,38 @@ struct PermissionActionButtons: View {
 struct QuickReplyButtons: View {
     @ObservedObject var stateManager: IslandStateManager
     let labels: [String]
+    let eventID: UUID
+
+    private var expired: Bool { stateManager.currentEventExpired }
 
     var body: some View {
-        HStack(spacing: 12) {
-            ForEach(labels, id: \.self) { label in
-                Button(action: {
-                    stateManager.server?.setResponse(label)
-                    stateManager.dismiss()
-                }) {
-                    Text(label)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(.white.opacity(0.95))
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 8)
-                        .background(
-                            RoundedRectangle(cornerRadius: 10)
-                                .fill(Color.white.opacity(0.12))
-                        )
+        VStack(spacing: 6) {
+            HStack(spacing: 12) {
+                ForEach(labels, id: \.self) { label in
+                    Button(action: {
+                        stateManager.server?.setResponse(label, eventID: eventID)
+                        stateManager.dismiss()
+                    }) {
+                        Text(label)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(.white.opacity(0.95))
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 8)
+                            .background(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .fill(Color.white.opacity(0.12))
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(expired)
                 }
-                .buttonStyle(.plain)
+            }
+            .opacity(expired ? 0.5 : 1)
+
+            if expired {
+                Text("Reply window expired — dismiss and re-trigger to respond.")
+                    .font(.system(size: 10))
+                    .foregroundColor(.white.opacity(0.55))
             }
         }
     }

--- a/Sources/DynamicIsland/LocalServer.swift
+++ b/Sources/DynamicIsland/LocalServer.swift
@@ -45,33 +45,50 @@ struct PermissionDecision {
     }
 }
 
+/// Decision parked for the long-polling hook, scoped to the originating
+/// event. The eventID guard means a click that arrives after the hook's
+/// long-poll horizon expired can't be harvested by an unrelated later
+/// event's poll (issue #31).
+struct PendingResponse {
+    let eventID: UUID
+    let decision: PermissionDecision
+}
+
+private struct ResponseWaiter {
+    let eventID: UUID
+    let continuation: CheckedContinuation<PermissionDecision, Never>
+}
+
 class LocalServer {
     let port: UInt16
     private var listener: NWListener?
     private weak var stateManager: IslandStateManager?
 
     /// Pending permission response — hook script polls this
-    private var pendingResponse: PermissionDecision?
+    private var pendingResponse: PendingResponse?
     private let responseLock = NSLock()
-    private var responseWaiters: [CheckedContinuation<PermissionDecision, Never>] = []
+    private var responseWaiters: [ResponseWaiter] = []
 
     init(stateManager: IslandStateManager, port: UInt16 = 9423) {
         self.stateManager = stateManager
         self.port = port
     }
 
-    /// Called from UI when user taps Allow/Deny/Always.
-    func setResponse(_ behavior: String, rule: PermissionRuleSuggestion? = nil) {
+    /// Called from UI when user taps Allow/Deny/Always or a quick reply.
+    /// `eventID` scopes the response to the originating event so late
+    /// clicks (after the hook's long-poll timed out) can't leak into an
+    /// unrelated subsequent event.
+    func setResponse(_ behavior: String, rule: PermissionRuleSuggestion? = nil, eventID: UUID) {
         let decision = PermissionDecision(behavior: behavior, rule: rule)
         responseLock.lock()
-        let waiters = responseWaiters
-        responseWaiters.removeAll()
-        if waiters.isEmpty {
-            pendingResponse = decision
+        let matching = responseWaiters.filter { $0.eventID == eventID }
+        responseWaiters.removeAll { $0.eventID == eventID }
+        if matching.isEmpty {
+            pendingResponse = PendingResponse(eventID: eventID, decision: decision)
         }
         responseLock.unlock()
-        for waiter in waiters {
-            waiter.resume(returning: decision)
+        for waiter in matching {
+            waiter.continuation.resume(returning: decision)
         }
     }
 
@@ -179,7 +196,7 @@ class LocalServer {
     /// `handleConnection` switch — just unblocked from read-loop concerns.
     private func dispatch(connection: NWConnection, request: HTTPRequest) {
         if request.path.hasPrefix("/response") {
-            handleResponsePoll(connection)
+            handleResponsePoll(connection, requestPath: request.path)
         } else if request.path.hasPrefix("/event") {
             do {
                 guard !request.body.isEmpty else {
@@ -252,14 +269,25 @@ class LocalServer {
         })
     }
 
-    /// Long-poll: waits up to 25s for user to tap Allow/Deny/Always, then returns the choice
-    private func handleResponsePoll(_ connection: NWConnection) {
+    /// Long-poll: waits up to 25 s for user to tap Allow/Deny/Always or a
+    /// quick reply for the event matching `event_id`, then returns the
+    /// choice. A poll without `event_id`, or with one that never matches,
+    /// returns "timeout" — never a parked decision from another event.
+    private func handleResponsePoll(_ connection: NWConnection, requestPath: String) {
         let timeoutDecision = PermissionDecision(behavior: "timeout", rule: nil)
+
+        guard let eventID = Self.parseEventID(from: requestPath) else {
+            // Hook didn't supply an event_id — refuse to hand out a parked
+            // decision since we can't prove it belongs to this caller.
+            sendHTTP(connection, body: timeoutDecision.jsonBody)
+            return
+        }
+
         responseLock.lock()
-        if let response = pendingResponse {
+        if let pending = pendingResponse, pending.eventID == eventID {
             pendingResponse = nil
             responseLock.unlock()
-            sendHTTP(connection, body: response.jsonBody)
+            sendHTTP(connection, body: pending.decision.jsonBody)
             return
         }
         responseLock.unlock()
@@ -270,13 +298,13 @@ class LocalServer {
                 group.addTask {
                     await withCheckedContinuation { continuation in
                         self.responseLock.lock()
-                        // Check again in case it arrived
-                        if let response = self.pendingResponse {
+                        // Check again in case it arrived for our event
+                        if let pending = self.pendingResponse, pending.eventID == eventID {
                             self.pendingResponse = nil
                             self.responseLock.unlock()
-                            continuation.resume(returning: response)
+                            continuation.resume(returning: pending.decision)
                         } else {
-                            self.responseWaiters.append(continuation)
+                            self.responseWaiters.append(ResponseWaiter(eventID: eventID, continuation: continuation))
                             self.responseLock.unlock()
                         }
                     }
@@ -292,6 +320,18 @@ class LocalServer {
 
             self.sendHTTP(connection, body: result.jsonBody)
         }
+    }
+
+    private static func parseEventID(from path: String) -> UUID? {
+        guard let queryStart = path.firstIndex(of: "?") else { return nil }
+        let query = path[path.index(after: queryStart)...]
+        for pair in query.split(separator: "&") {
+            let kv = pair.split(separator: "=", maxSplits: 1).map(String.init)
+            if kv.count == 2, kv[0] == "event_id" {
+                return UUID(uuidString: kv[1])
+            }
+        }
+        return nil
     }
 
     private func processEvent(_ data: Data) throws {
@@ -378,7 +418,14 @@ class LocalServer {
             }
         }
 
+        // Adopt the hook's event_id so the UI's setResponse poll can be
+        // matched back to this event (#31). Falls back to a fresh UUID for
+        // legacy callers / manual POSTs without one.
+        let payloadID = (json["event_id"] as? String).flatMap(UUID.init(uuidString:))
+        let agentIDValue = json["agent_id"] as? String
+        let sessionIDValue = json["session_id"] as? String
         let event = IslandEvent(
+            id: payloadID ?? UUID(),
             icon: icon,
             title: title,
             subtitle: subtitle,
@@ -390,7 +437,9 @@ class LocalServer {
             project: project,
             source: source,
             suggestedRule: suggestedRule,
-            quickReplies: quickReplies
+            quickReplies: quickReplies,
+            agentID: agentIDValue,
+            sessionID: sessionIDValue
         )
 
         // Route into the session tree: main session when no agent_id, else

--- a/Sources/IslandHookCore/HookPlan.swift
+++ b/Sources/IslandHookCore/HookPlan.swift
@@ -136,6 +136,12 @@ extension HookPlan {
         if let id = agentId, !id.isEmpty { p["agent_id"] = id }
         if let t = agentType, !t.isEmpty { p["agent_type"] = t }
         if !source.isEmpty { p["source"] = source }
+        // Forward Claude Code's session UUID so the island can tell two
+        // main sessions in the same project apart — needed for the
+        // "user resolved on the terminal side" detection (#31 follow-up).
+        if let sid = payload["session_id"] as? String, !sid.isEmpty {
+            p["session_id"] = sid
+        }
         return p
     }
 

--- a/Sources/island-hook/main.swift
+++ b/Sources/island-hook/main.swift
@@ -14,6 +14,11 @@ let port = ProcessInfo.processInfo.environment["DYNAMIC_ISLAND_PORT"]
 let eventURL = URL(string: "http://127.0.0.1:\(port)/event")!
 let responseURL = URL(string: "http://127.0.0.1:\(port)/response")!
 
+/// One UUID per hook invocation — the IslandEvent it produces and any
+/// subsequent `/response` poll share it so a late click from a previous
+/// event can't get harvested by this hook (issue #31).
+let eventID = UUID().uuidString.lowercased()
+
 // MARK: - Parse stdin
 
 let inputData = FileHandle.standardInput.readDataToEndOfFile()
@@ -26,7 +31,9 @@ else { exit(0) }
 // MARK: - I/O helpers
 
 func send(_ body: [String: Any]) {
-    guard let data = try? JSONSerialization.data(withJSONObject: body) else { return }
+    var enriched = body
+    enriched["event_id"] = eventID
+    guard let data = try? JSONSerialization.data(withJSONObject: enriched) else { return }
     var req = URLRequest(url: eventURL)
     req.httpMethod = "POST"
     req.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -44,7 +51,11 @@ struct PermissionDecision {
 }
 
 func longPollResponse(timeoutSeconds: TimeInterval) -> PermissionDecision {
-    var req = URLRequest(url: responseURL)
+    // Scope the poll to this hook's event so a parked decision from an
+    // earlier (timed-out) event can't satisfy us — see issue #31.
+    var components = URLComponents(url: responseURL, resolvingAgainstBaseURL: false)!
+    components.queryItems = [URLQueryItem(name: "event_id", value: eventID)]
+    var req = URLRequest(url: components.url!)
     req.timeoutInterval = timeoutSeconds + 1
     var decision = PermissionDecision(behavior: "timeout", rule: nil)
     let sem = DispatchSemaphore(value: 0)


### PR DESCRIPTION
Closes #31.

## Summary

Three related changes that together stop late `/response` clicks from
leaking into unrelated subsequent events, and let the user see what
happened when their click would have been too late to matter.

### 1. Wire layer — eventID-scoped `/response`

Every hook invocation generates a UUID, attaches it to its `/event`
POST, and uses the same id when polling `/response`. The server
matches by id; an unmatched parked decision waits for its specific
waiter rather than leaking to whoever polls next. Polls without an
`event_id` get the timeout decision — never a parked one.

- `island-hook`: per-process UUID, `send()` injects `event_id`,
  `longPollResponse` sends `?event_id=<uuid>`.
- `LocalServer`: `pendingResponse: PendingResponse?` (eventID +
  decision). `responseWaiters` carries eventID. `processEvent`
  adopts the payload's `event_id` as `IslandEvent.id`.
- `IslandView`: every `setResponse(...)` call site (`PermissionActionButtons` × 3,
  `QuickReplyButtons` × 1) now passes `eventID: event.id`. Both
  button views grew an `eventID: UUID` parameter.

### 2. UX layer — expired hint + auto-dismiss

A late click that the wire layer rejects would otherwise look like a
silent no-op. To avoid that:

- `IslandStateManager.currentEventExpired: Bool` (`@Published`) plus
  an `expirationTimer` started in `showEvent` for events with a
  decision affordance. Timeout matches the hook side: 25 s for
  `.action`, `StopReplyTimeoutSeconds` for `.reminder + quickReplies`.
- When the timer fires, `currentEventExpired` flips and a follow-up
  5 s `dismiss()` is scheduled so the pill doesn't sit on screen
  forever. The `pushEvent` queue guard releases on `expired` so the
  slot opens for new events before the auto-dismiss fires.
- `PermissionActionButtons` / `QuickReplyButtons` read the flag,
  disable themselves, drop to 0.5 opacity, and show "Reply window
  expired — dismiss and re-trigger to respond." underneath.

### 3. Same-session takeover

When the user answers Claude's native terminal prompt instead of the
island, the next non-decision event from the same Claude session
(`PreToolUse`, `PostToolUse`, etc.) is the strongest signal that the
user moved on. The `pushEvent` queue guard now releases when an
incoming non-decision event matches `currentEvent` on
`(sessionID || (project, agentID))`. Other-session transients are
still dropped so a noisy parallel session can't disturb the active
decision.

To make the comparison possible:
- `IslandHookCore.HookPlan.decorate` forwards `session_id`.
- `IslandEvent` gains `sessionID: String?` and `agentID: String?`.
- `LocalServer.processEvent` reads both from the payload.

## Scope notes

`Package.swift`: `DynamicIsland` now depends on `IslandHookCore`
because `IslandStateManager` reads `StopReplyTimeoutSeconds` to keep
the UI's expiration timer in sync with the hook's long-poll horizon.

Notch and capsule UI behaviour are otherwise unchanged — same Allow /
Deny / Always allow / quick-reply layout, just gains the disabled +
expired hint state when the hook would no longer be listening.

## Test plan

- [x] PermissionRequest hook end-to-end: pill shows, click Allow within
  timeout → hook receives matching decision, Claude continues.
- [x] PermissionRequest hook end-to-end: don't click for 25 s →
  buttons grey out + "Reply window expired" appears, pill auto-
  dismisses 5 s later.
- [x] Two `/response` polls with different `event_id`s, only one parked
  decision: server resolves the matching poll, the other times out.
- [x] Same-session takeover: PermissionRequest pill showing, send a
  PreToolUse with the same `session_id` → pill switches to the new
  event without waiting for the old hook to time out.
- [x] Cross-session protection still holds: PermissionRequest from
  session A showing, transient from session B → B is dropped.
- [ ] Race-condition tests under XCTest — current local toolchain
  doesn't ship XCTest (`CommandLineTools` only); leaving for CI to
  exercise.

## Known limitation

If two main Claude sessions run in the **same project directory**
without distinct `session_id`s, the same-session takeover heuristic
will treat them as one and one's transient will collapse the other's
pending decision. Real-world Claude Code always sets `session_id`, so
this only affects manual `curl` flows that omit it.