### PR TITLE
fix(codex): menu reinstall, auto-sync after upgrade, accurate install message, drop Claude-only suggested rule

### DIFF
--- a/Sources/DynamicIsland/App.swift
+++ b/Sources/DynamicIsland/App.swift
@@ -173,6 +173,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             title: "Reinstall Claude Code Hooks",
             action: #selector(reinstallHooks),
             keyEquivalent: ""))
+        menu.addItem(NSMenuItem(
+            title: "Reinstall Codex Hooks",
+            action: #selector(reinstallCodexHooks),
+            keyEquivalent: ""))
         menu.addItem(.separator())
         let quit = NSMenuItem(
             title: "Quit Dynamic Island",
@@ -211,10 +215,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func reinstallHooks() {
         let result = HookInstaller.install(target: .claudeCode)
-        reportInstallResult(result)
+        reportInstallResult(result, target: .claudeCode)
         if case .installed = result {
             UserDefaults.standard.set("installed", forKey: Self.hookChoiceKey)
         }
+    }
+
+    @objc private func reinstallCodexHooks() {
+        let result = HookInstaller.install(target: .codex)
+        reportInstallResult(result, target: .codex)
     }
 
     private func maybePromptForHookInstall() {
@@ -225,6 +234,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             break
         default:
             showInstallPrompt()
+        }
+
+        // Codex hooks are installed explicitly via CLI/menu, but once present
+        // they need the same binary drift repair as Claude hooks after app
+        // upgrades.
+        if HookInstaller.hasExistingInstall(target: .codex) {
+            _ = HookInstaller.syncIfOutdated(target: .codex)
         }
     }
 
@@ -253,7 +269,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         case .alertFirstButtonReturn:   // Install
             let result = HookInstaller.install(target: .claudeCode)
             UserDefaults.standard.set("installed", forKey: Self.hookChoiceKey)
-            reportInstallResult(result)
+            reportInstallResult(result, target: .claudeCode)
         case .alertThirdButtonReturn:   // Never
             UserDefaults.standard.set("declined", forKey: Self.hookChoiceKey)
         default:                        // Skip — ask again next launch
@@ -261,12 +277,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    private func reportInstallResult(_ result: HookInstaller.Result) {
+    private func reportInstallResult(_ result: HookInstaller.Result, target: HookInstaller.Target) {
         switch result {
         case .installed:
             stateManager.pushEvent(IslandEvent(
-                title: "Hooks installed",
-                subtitle: "~/.claude/hooks/dynamic-island-hook",
+                title: "\(target.displayName) hooks installed",
+                subtitle: target.deployedHookURL.path,
                 style: .success,
                 duration: 4.0
             ))

--- a/Sources/DynamicIsland/HookInstaller.swift
+++ b/Sources/DynamicIsland/HookInstaller.swift
@@ -162,6 +162,11 @@ enum HookInstaller {
         }
     }
 
+    static func hasExistingInstall(target: Target) -> Bool {
+        anyOurEntryExists(target: target)
+            || FileManager.default.fileExists(atPath: target.deployedHookURL.path)
+    }
+
     // MARK: - Source resolution
 
     /// Locates the bundled `island-hook` binary that we deploy into the user's

--- a/Sources/IslandHookCore/PayloadBuilder.swift
+++ b/Sources/IslandHookCore/PayloadBuilder.swift
@@ -206,7 +206,8 @@ public func buildPermissionRequestPayload(
     // uses this to offer a third button; when chosen, the hook echoes the
     // pattern back to Claude Code via `updatedPermissions`.
     let effectiveInput = (cachedToolName == toolName ? cachedInput : nil) ?? plan.toolInput
-    if let rule = suggestPermissionRule(toolName: toolName, toolInput: effectiveInput) {
+    if plan.source == "claude",
+       let rule = suggestPermissionRule(toolName: toolName, toolInput: effectiveInput) {
         p["suggested_rule"] = [
             "toolName": rule.toolName,
             "ruleContent": rule.ruleContent,

--- a/Tests/IslandHookCoreTests/PayloadBuilderTests.swift
+++ b/Tests/IslandHookCoreTests/PayloadBuilderTests.swift
@@ -429,6 +429,16 @@ final class PayloadBuilderTests: XCTestCase {
         XCTAssertNil(body["detail"])
     }
 
+    func testPermissionRequest_CodexDoesNotSuggestPersistentRule() {
+        let p = plan([
+            "hook_event_name": "PermissionRequest", "tool_name": "Bash",
+            "tool_input": ["command": "gh issue list --state open"],
+            "cwd": "/tmp",
+        ], env: ["ISLAND_SOURCE": "codex"])
+        let body = buildPermissionRequestPayload(p)
+        XCTAssertNil(body["suggested_rule"])
+    }
+
     // MARK: - Session lifecycle
 
     func testSessionStart_usesSourceField() {


### PR DESCRIPTION
Closes #33.

## Summary

Four Codex-integration bugs found while smoke-testing v1.6.3. All
have been latent since the Codex CLI flags landed (v1.6.1) — only
surface once you actually use Codex.

## What this PR does

### Menu (`App.swift`)

Adds a "Reinstall Codex Hooks" menu item next to the existing Claude
one. Same `HookInstaller.install(target:)` call site as the prompt
flow — no new code path. Doesn't write to `hookInstallChoiceKey`
because that key gates Claude's first-launch prompt and shouldn't be
co-opted by Codex.

### Auto-sync (`HookInstaller.swift` + `App.swift`)

New `HookInstaller.hasExistingInstall(target:)` helper: detects an
existing install via either an entry in the target's settings file
or the deployed binary on disk. `maybePromptForHookInstall` now
calls `syncIfOutdated(target: .codex)` after the Claude prompt
path, gated on `hasExistingInstall(target: .codex)` — Codex isn't
auto-installed on first launch (CLI-only), but once present gets
the same byte-compare drift repair as Claude.

### Install message (`App.swift`)

`reportInstallResult` now takes a `target: HookInstaller.Target`,
reads `target.displayName` and `target.deployedHookURL.path` so the
notification accurately reflects the install destination.

### Suggested rule (`PayloadBuilder.swift`)

`buildPermissionRequestPayload` only attaches `suggested_rule` when
`plan.source == "claude"`. Codex / Copilot get the standard Allow /
Deny only.

## Test plan

- [x] `swift build` clean, **124 tests pass** (one new in
  `PayloadBuilderTests`).
- [x] `testPermissionRequest_CodexDoesNotSuggestPersistentRule` —
  `ISLAND_SOURCE=codex` Bash permission request omits
  `suggested_rule`.
- [ ] Live Codex menu reinstall — manual test.
- [ ] Live app upgrade with stale Codex binary → verify redeploy on
  next launch (easier to verify after a v1.6.4 ships over v1.6.3 in
  the wild).

## Out of scope

- Whether Codex grows its own persistent-rule mechanism — separate
  issue if/when Codex ships one.
- Auto-detect Codex installs from a fresh app launch (instead of
  CLI opt-in). Current PR keeps the explicit CLI gate; the auto-sync
  only kicks in for users who already opted in.