### PR TITLE
Fix response waiter timeout cleanup

### DIFF
--- a/Sources/DynamicIsland/IslandState.swift
+++ b/Sources/DynamicIsland/IslandState.swift
@@ -7,7 +7,7 @@ import IslandHookCore
 /// Suggested permission rule forwarded from the PermissionRequest hook so the
 /// capsule can offer an "Always allow" button. Mirrors the shape Claude Code
 /// expects inside `updatedPermissions.rules[]`.
-struct PermissionRuleSuggestion: Equatable {
+struct PermissionRuleSuggestion: Equatable, Sendable {
     let toolName: String    // e.g. "Bash"
     let ruleContent: String // e.g. "glab api *"
 }

--- a/Sources/DynamicIsland/LocalServer.swift
+++ b/Sources/DynamicIsland/LocalServer.swift
@@ -21,7 +21,7 @@ import DynamicIslandCore
 /// `rule` is non-nil only when the user chose "Always allow"; the hook
 /// forwards it to Claude Code as `updatedPermissions.rules[0]` so the
 /// pattern lands in the user's `localSettings`.
-struct PermissionDecision {
+struct PermissionDecision: Sendable {
     let behavior: String                     // "allow" | "deny"
     let rule: PermissionRuleSuggestion?
 
@@ -45,29 +45,12 @@ struct PermissionDecision {
     }
 }
 
-/// Decision parked for the long-polling hook, scoped to the originating
-/// event. The eventID guard means a click that arrives after the hook's
-/// long-poll horizon expired can't be harvested by an unrelated later
-/// event's poll (issue #31).
-struct PendingResponse {
-    let eventID: UUID
-    let decision: PermissionDecision
-}
-
-private struct ResponseWaiter {
-    let eventID: UUID
-    let continuation: CheckedContinuation<PermissionDecision, Never>
-}
-
 class LocalServer {
     let port: UInt16
     private var listener: NWListener?
     private weak var stateManager: IslandStateManager?
 
-    /// Pending permission response — hook script polls this
-    private var pendingResponse: PendingResponse?
-    private let responseLock = NSLock()
-    private var responseWaiters: [ResponseWaiter] = []
+    private let responseStore = ResponseWaiterStore<PermissionDecision>()
 
     init(stateManager: IslandStateManager, port: UInt16 = 9423) {
         self.stateManager = stateManager
@@ -80,15 +63,11 @@ class LocalServer {
     /// unrelated subsequent event.
     func setResponse(_ behavior: String, rule: PermissionRuleSuggestion? = nil, eventID: UUID) {
         let decision = PermissionDecision(behavior: behavior, rule: rule)
-        responseLock.lock()
-        let matching = responseWaiters.filter { $0.eventID == eventID }
-        responseWaiters.removeAll { $0.eventID == eventID }
-        if matching.isEmpty {
-            pendingResponse = PendingResponse(eventID: eventID, decision: decision)
-        }
-        responseLock.unlock()
-        for waiter in matching {
-            waiter.continuation.resume(returning: decision)
+        // UI button handlers are synchronous; hop into the actor and return
+        // immediately so the panel can dismiss without waiting on server state.
+        // The hook long-poll observes the decision on the next actor turn.
+        Task {
+            await responseStore.resolve(decision, eventID: eventID)
         }
     }
 
@@ -283,41 +262,12 @@ class LocalServer {
             return
         }
 
-        responseLock.lock()
-        if let pending = pendingResponse, pending.eventID == eventID {
-            pendingResponse = nil
-            responseLock.unlock()
-            sendHTTP(connection, body: pending.decision.jsonBody)
-            return
-        }
-        responseLock.unlock()
-
-        // Long-poll: wait for response with timeout
         Task {
-            let result = await withTaskGroup(of: PermissionDecision.self, returning: PermissionDecision.self) { group in
-                group.addTask {
-                    await withCheckedContinuation { continuation in
-                        self.responseLock.lock()
-                        // Check again in case it arrived for our event
-                        if let pending = self.pendingResponse, pending.eventID == eventID {
-                            self.pendingResponse = nil
-                            self.responseLock.unlock()
-                            continuation.resume(returning: pending.decision)
-                        } else {
-                            self.responseWaiters.append(ResponseWaiter(eventID: eventID, continuation: continuation))
-                            self.responseLock.unlock()
-                        }
-                    }
-                }
-                group.addTask {
-                    try? await Task.sleep(nanoseconds: 25_000_000_000) // 25s timeout
-                    return timeoutDecision
-                }
-                let first = await group.next()!
-                group.cancelAll()
-                return first
-            }
-
+            let result = await responseStore.wait(
+                eventID: eventID,
+                timeoutValue: timeoutDecision,
+                timeoutNanoseconds: 25_000_000_000
+            )
             self.sendHTTP(connection, body: result.jsonBody)
         }
     }

--- a/Sources/DynamicIslandCore/ResponseWaiterStore.swift
+++ b/Sources/DynamicIslandCore/ResponseWaiterStore.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Event-scoped response router for `/response` long-polls.
+///
+/// A UI click may arrive before the hook starts polling, so responses can be
+/// parked by event id. Once a poll times out, that event id is marked expired:
+/// a later click for the same stale UI must be dropped instead of parked for a
+/// future, unrelated poll.
+public actor ResponseWaiterStore<Value: Sendable> {
+    private struct Waiter {
+        let token: UUID
+        let continuation: CheckedContinuation<Value, Never>
+    }
+
+    private var pending: [UUID: Value] = [:]
+    private var waiters: [UUID: [Waiter]] = [:]
+    private var closed: Set<UUID> = []
+    private var closedOrder: [UUID] = []
+    // Bounded tombstone cache for events that have already resolved or timed
+    // out. 256 is deliberately generous for a UI affordance whose reply
+    // window is 25-30 s: it covers several minutes of repeated prompts while
+    // preventing an unbounded set if a local client keeps sending stale clicks.
+    private let expiredLimit = 256
+
+    public init() {}
+
+    public var waiterCount: Int {
+        waiters.values.reduce(0) { $0 + $1.count }
+    }
+
+    public var pendingCount: Int {
+        pending.count
+    }
+
+    public func resolve(_ value: Value, eventID: UUID) {
+        guard !closed.contains(eventID) else { return }
+
+        if let parked = waiters.removeValue(forKey: eventID), !parked.isEmpty {
+            markClosed(eventID)
+            for waiter in parked {
+                waiter.continuation.resume(returning: value)
+            }
+            return
+        }
+
+        // A second click before the hook starts polling should not overwrite
+        // the first response the user chose.
+        guard pending[eventID] == nil else { return }
+        pending[eventID] = value
+    }
+
+    public func wait(
+        eventID: UUID,
+        timeoutValue: Value,
+        timeoutNanoseconds: UInt64
+    ) async -> Value {
+        if let value = pending.removeValue(forKey: eventID) {
+            markClosed(eventID)
+            return value
+        }
+        if closed.contains(eventID) {
+            return timeoutValue
+        }
+
+        let token = UUID()
+        return await withCheckedContinuation { continuation in
+            waiters[eventID, default: []].append(Waiter(
+                token: token,
+                continuation: continuation
+            ))
+            Task {
+                try? await Task.sleep(nanoseconds: timeoutNanoseconds)
+                self.timeout(eventID: eventID, token: token, value: timeoutValue)
+            }
+        }
+    }
+
+    private func timeout(eventID: UUID, token: UUID, value: Value) {
+        guard var parked = waiters[eventID],
+              let idx = parked.firstIndex(where: { $0.token == token }) else {
+            return
+        }
+
+        let waiter = parked.remove(at: idx)
+        if parked.isEmpty {
+            waiters.removeValue(forKey: eventID)
+        } else {
+            waiters[eventID] = parked
+        }
+        markClosed(eventID)
+        waiter.continuation.resume(returning: value)
+    }
+
+    private func markClosed(_ eventID: UUID) {
+        if closed.insert(eventID).inserted {
+            closedOrder.append(eventID)
+        }
+        while closedOrder.count > expiredLimit {
+            let old = closedOrder.removeFirst()
+            closed.remove(old)
+        }
+    }
+}

--- a/Tests/DynamicIslandCoreTests/ResponseWaiterStoreTests.swift
+++ b/Tests/DynamicIslandCoreTests/ResponseWaiterStoreTests.swift
@@ -1,0 +1,176 @@
+import XCTest
+@testable import DynamicIslandCore
+
+final class ResponseWaiterStoreTests: XCTestCase {
+    func testResponseBeforePollIsDeliveredOnce() async {
+        let store = ResponseWaiterStore<String>()
+        let eventID = UUID()
+
+        await store.resolve("allow", eventID: eventID)
+        let pendingBeforePoll = await store.pendingCount
+        XCTAssertEqual(pendingBeforePoll, 1)
+
+        let result = await store.wait(
+            eventID: eventID,
+            timeoutValue: "timeout",
+            timeoutNanoseconds: 1_000_000
+        )
+        XCTAssertEqual(result, "allow")
+        let pendingAfterPoll = await store.pendingCount
+        let waitersAfterPoll = await store.waiterCount
+        XCTAssertEqual(pendingAfterPoll, 0)
+        XCTAssertEqual(waitersAfterPoll, 0)
+    }
+
+    func testResponseDuringPollResolvesAndRemovesWaiter() async {
+        let store = ResponseWaiterStore<String>()
+        let eventID = UUID()
+
+        let poll = Task {
+            await store.wait(
+                eventID: eventID,
+                timeoutValue: "timeout",
+                timeoutNanoseconds: 1_000_000_000
+            )
+        }
+        await waitForWaiters(store, count: 1)
+
+        await store.resolve("deny", eventID: eventID)
+        let result = await poll.value
+
+        XCTAssertEqual(result, "deny")
+        let pending = await store.pendingCount
+        let waiters = await store.waiterCount
+        XCTAssertEqual(pending, 0)
+        XCTAssertEqual(waiters, 0)
+    }
+
+    func testTimeoutResolvesAndRemovesWaiter() async {
+        let store = ResponseWaiterStore<String>()
+        let eventID = UUID()
+
+        let result = await store.wait(
+            eventID: eventID,
+            timeoutValue: "timeout",
+            timeoutNanoseconds: 1_000_000
+        )
+
+        XCTAssertEqual(result, "timeout")
+        let pending = await store.pendingCount
+        let waiters = await store.waiterCount
+        XCTAssertEqual(pending, 0)
+        XCTAssertEqual(waiters, 0)
+    }
+
+    func testLateResponseAfterTimeoutIsDropped() async {
+        let store = ResponseWaiterStore<String>()
+        let eventID = UUID()
+
+        let result = await store.wait(
+            eventID: eventID,
+            timeoutValue: "timeout",
+            timeoutNanoseconds: 1_000_000
+        )
+        XCTAssertEqual(result, "timeout")
+
+        await store.resolve("allow", eventID: eventID)
+        let pending = await store.pendingCount
+        let waiters = await store.waiterCount
+        XCTAssertEqual(pending, 0)
+        XCTAssertEqual(waiters, 0)
+
+        let second = await store.wait(
+            eventID: eventID,
+            timeoutValue: "timeout",
+            timeoutNanoseconds: 1_000_000
+        )
+        XCTAssertEqual(second, "timeout")
+    }
+
+    func testDuplicateResponseAfterResolveIsDropped() async {
+        let store = ResponseWaiterStore<String>()
+        let eventID = UUID()
+
+        let poll = Task {
+            await store.wait(
+                eventID: eventID,
+                timeoutValue: "timeout",
+                timeoutNanoseconds: 1_000_000_000
+            )
+        }
+        await waitForWaiters(store, count: 1)
+
+        await store.resolve("allow", eventID: eventID)
+        let result = await poll.value
+        XCTAssertEqual(result, "allow")
+
+        await store.resolve("allow", eventID: eventID)
+        let pending = await store.pendingCount
+        let waiters = await store.waiterCount
+        XCTAssertEqual(pending, 0)
+        XCTAssertEqual(waiters, 0)
+    }
+
+    func testDuplicateResponseBeforePollKeepsFirstChoice() async {
+        let store = ResponseWaiterStore<String>()
+        let eventID = UUID()
+
+        await store.resolve("allow", eventID: eventID)
+        await store.resolve("deny", eventID: eventID)
+
+        let result = await store.wait(
+            eventID: eventID,
+            timeoutValue: "timeout",
+            timeoutNanoseconds: 1_000_000
+        )
+        XCTAssertEqual(result, "allow")
+        let pending = await store.pendingCount
+        XCTAssertEqual(pending, 0)
+    }
+
+    func testEventIDIsolation() async {
+        let store = ResponseWaiterStore<String>()
+        let eventA = UUID()
+        let eventB = UUID()
+
+        let pollB = Task {
+            await store.wait(
+                eventID: eventB,
+                timeoutValue: "timeout",
+                timeoutNanoseconds: 5_000_000
+            )
+        }
+        await waitForWaiters(store, count: 1)
+
+        await store.resolve("allow", eventID: eventA)
+        let pendingAfterA = await store.pendingCount
+        XCTAssertEqual(pendingAfterA, 1)
+
+        let resultB = await pollB.value
+        XCTAssertEqual(resultB, "timeout")
+        let waiters = await store.waiterCount
+        XCTAssertEqual(waiters, 0)
+
+        let resultA = await store.wait(
+            eventID: eventA,
+            timeoutValue: "timeout",
+            timeoutNanoseconds: 1_000_000
+        )
+        XCTAssertEqual(resultA, "allow")
+        let pendingAfterConsume = await store.pendingCount
+        XCTAssertEqual(pendingAfterConsume, 0)
+    }
+
+    private func waitForWaiters(
+        _ store: ResponseWaiterStore<String>,
+        count: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        for _ in 0..<100 {
+            if await store.waiterCount == count { return }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        XCTFail("timed out waiting for \(count) waiter(s)", file: file, line: line)
+    }
+}


### PR DESCRIPTION
## Summary
- extract event-scoped /response routing into `ResponseWaiterStore`
- remove stale waiters on timeout and drop late responses for expired event ids
- add regression coverage for pre-poll, in-flight, timeout, late-response, and event-id isolation paths

## Tests
- `swift test`

Closes #35