### PR TITLE
Make hook config writes atomic

### DIFF
--- a/Sources/DynamicIsland/HookInstaller.swift
+++ b/Sources/DynamicIsland/HookInstaller.swift
@@ -1,3 +1,4 @@
+import DynamicIslandCore
 import Foundation
 
 /// Deploys the bundled `island-hook` binary and registers hook events for
@@ -196,14 +197,13 @@ enum HookInstaller {
     }
 
     private static func deployHookScript(from source: URL, to dest: URL) throws {
-        let dir = dest.deletingLastPathComponent()
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        if FileManager.default.fileExists(atPath: dest.path) {
-            try FileManager.default.removeItem(at: dest)
-        }
-        try FileManager.default.copyItem(at: source, to: dest)
-        try FileManager.default.setAttributes(
-            [.posixPermissions: 0o755], ofItemAtPath: dest.path)
+        let data = try Data(contentsOf: source)
+        try AtomicFileWriter.write(
+            data,
+            to: dest,
+            backupExisting: false,
+            posixPermissions: 0o755
+        )
     }
 
     // MARK: - Settings manipulation
@@ -312,12 +312,18 @@ enum HookInstaller {
     /// proceed if the existing file is unreadable JSON.
     private static func writeSettings(target: Target, shouldHaveHooks: Bool) throws {
         let url = target.settingsURL
+        let fingerprint = try AtomicFileWriter.fingerprint(at: url)
         var root: [String: Any] = [:]
-        if let data = try? Data(contentsOf: url), !data.isEmpty {
-            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                throw SettingsParseError(path: url.path)
+        if fingerprint.exists {
+            let data = try Data(contentsOf: url)
+            if data.isEmpty {
+                root = [:]
+            } else {
+                guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                    throw SettingsParseError(path: url.path)
+                }
+                root = json
             }
-            root = json
         }
         var hooks = root["hooks"] as? [String: Any] ?? [:]
 
@@ -354,12 +360,9 @@ enum HookInstaller {
             root["version"] = 1
         }
 
-        let parent = url.deletingLastPathComponent()
-        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
-
         let data = try JSONSerialization.data(
             withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
-        try data.write(to: url)
+        try AtomicFileWriter.write(data, to: url, expectedFingerprint: fingerprint)
     }
 
     private static func newEntry(
@@ -408,12 +411,20 @@ enum HookInstaller {
 
     private static func ensureCodexHooksFeatureEnabled() throws {
         guard let url = Target.codex.codexConfigURL else { return }
-        let existing = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+        let fingerprint = try AtomicFileWriter.fingerprint(at: url)
+        let existing: String
+        if fingerprint.exists {
+            existing = try String(contentsOf: url, encoding: .utf8)
+        } else {
+            existing = ""
+        }
         let updated = setTomlBool(true, for: "codex_hooks", inSection: "features", content: existing)
 
-        let parent = url.deletingLastPathComponent()
-        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
-        try updated.write(to: url, atomically: true, encoding: .utf8)
+        try AtomicFileWriter.write(
+            Data(updated.utf8),
+            to: url,
+            expectedFingerprint: fingerprint
+        )
     }
 
     private static func tomlBoolValue(

--- a/Sources/DynamicIslandCore/AtomicFileWriter.swift
+++ b/Sources/DynamicIslandCore/AtomicFileWriter.swift
@@ -106,6 +106,8 @@ public struct AtomicFileWriter {
     }
 
     private static func bestEffortSyncDirectory(at url: URL) {
+        // APFS/HFS+ directory fsync semantics are weaker than Linux's; this is
+        // still useful as a best-effort flush of the rename's directory entry.
         let fd = Darwin.open(url.path, O_RDONLY)
         guard fd >= 0 else { return }
         _ = Darwin.fsync(fd)

--- a/Sources/DynamicIslandCore/AtomicFileWriter.swift
+++ b/Sources/DynamicIslandCore/AtomicFileWriter.swift
@@ -1,0 +1,147 @@
+import Darwin
+import Foundation
+
+public enum AtomicFileWriteError: LocalizedError, Equatable {
+    case changedExternally(path: String)
+    case renameFailed(path: String, errno: Int32)
+
+    public var errorDescription: String? {
+        switch self {
+        case .changedExternally(let path):
+            return "\(path) changed while preparing an update; refusing to overwrite. Retry after reviewing the file."
+        case .renameFailed(let path, let errno):
+            return "Failed to atomically replace \(path): \(String(cString: strerror(errno)))"
+        }
+    }
+}
+
+public struct AtomicFileWriter {
+    public struct Fingerprint: Equatable {
+        public let exists: Bool
+        public let modificationDate: Date?
+        public let fileSize: UInt64?
+        public let contentDigest: UInt64?
+    }
+
+    public static func fingerprint(at url: URL) throws -> Fingerprint {
+        let manager = FileManager.default
+        guard manager.fileExists(atPath: url.path) else {
+            return Fingerprint(
+                exists: false,
+                modificationDate: nil,
+                fileSize: nil,
+                contentDigest: nil
+            )
+        }
+        let attrs = try manager.attributesOfItem(atPath: url.path)
+        let data = try Data(contentsOf: url)
+        return Fingerprint(
+            exists: true,
+            modificationDate: attrs[.modificationDate] as? Date,
+            fileSize: (attrs[.size] as? NSNumber)?.uint64Value,
+            contentDigest: digest(data)
+        )
+    }
+
+    public static func write(
+        _ data: Data,
+        to destination: URL,
+        backupExisting: Bool = true,
+        expectedFingerprint: Fingerprint? = nil,
+        posixPermissions: Int? = nil
+    ) throws {
+        let manager = FileManager.default
+        let directory = destination.deletingLastPathComponent()
+        try manager.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let tempURL = directory.appendingPathComponent(
+            ".\(destination.lastPathComponent).\(UUID().uuidString).tmp")
+        var tempCreated = false
+
+        do {
+            try data.write(to: tempURL, options: [])
+            tempCreated = true
+            let permissions: Int?
+            if let posixPermissions {
+                permissions = posixPermissions
+            } else {
+                permissions = try existingPermissions(at: destination)
+            }
+            if let permissions {
+                try manager.setAttributes([.posixPermissions: permissions], ofItemAtPath: tempURL.path)
+            }
+            bestEffortSyncFile(at: tempURL)
+
+            if let expectedFingerprint,
+               try fingerprint(at: destination) != expectedFingerprint {
+                throw AtomicFileWriteError.changedExternally(path: destination.path)
+            }
+
+            if backupExisting {
+                try createBackupIfNeeded(for: destination)
+            }
+
+            if Darwin.rename(tempURL.path, destination.path) != 0 {
+                throw AtomicFileWriteError.renameFailed(path: destination.path, errno: errno)
+            }
+            tempCreated = false
+            bestEffortSyncDirectory(at: directory)
+        } catch {
+            if tempCreated {
+                try? manager.removeItem(at: tempURL)
+            }
+            throw error
+        }
+    }
+
+    public static func backupURL(for destination: URL) -> URL {
+        destination.deletingLastPathComponent()
+            .appendingPathComponent(destination.lastPathComponent + ".bak")
+    }
+
+    private static func bestEffortSyncFile(at url: URL) {
+        guard let handle = try? FileHandle(forWritingTo: url) else { return }
+        defer { try? handle.close() }
+        try? handle.synchronize()
+    }
+
+    private static func bestEffortSyncDirectory(at url: URL) {
+        let fd = Darwin.open(url.path, O_RDONLY)
+        guard fd >= 0 else { return }
+        _ = Darwin.fsync(fd)
+        _ = Darwin.close(fd)
+    }
+
+    private static func createBackupIfNeeded(for destination: URL) throws {
+        let manager = FileManager.default
+        guard manager.fileExists(atPath: destination.path) else { return }
+
+        let backupURL = backupURL(for: destination)
+        let backupFingerprint = try fingerprint(at: backupURL)
+        guard !backupFingerprint.exists else { return }
+
+        let data = try Data(contentsOf: destination)
+        try write(
+            data,
+            to: backupURL,
+            backupExisting: false,
+            expectedFingerprint: backupFingerprint,
+            posixPermissions: try existingPermissions(at: destination)
+        )
+    }
+
+    private static func existingPermissions(at url: URL) throws -> Int? {
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+        return (attrs[.posixPermissions] as? NSNumber)?.intValue
+    }
+
+    private static func digest(_ data: Data) -> UInt64 {
+        var hash: UInt64 = 14_695_981_039_346_656_037
+        for byte in data {
+            hash ^= UInt64(byte)
+            hash &*= 1_099_511_628_211
+        }
+        return hash
+    }
+}

--- a/Tests/DynamicIslandCoreTests/AtomicFileWriterTests.swift
+++ b/Tests/DynamicIslandCoreTests/AtomicFileWriterTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import DynamicIslandCore
+
+final class AtomicFileWriterTests: XCTestCase {
+    func testWriteCreatesFileAtomically() throws {
+        let directory = try makeTemporaryDirectory()
+        let url = directory.appendingPathComponent("settings.json")
+
+        try AtomicFileWriter.write(Data(#"{"ok":true}"#.utf8), to: url)
+
+        XCTAssertEqual(try Data(contentsOf: url), Data(#"{"ok":true}"#.utf8))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: AtomicFileWriter.backupURL(for: url).path))
+        XCTAssertTrue(try temporaryFiles(in: directory).isEmpty)
+    }
+
+    func testOverwriteCreatesBackupOnce() throws {
+        let directory = try makeTemporaryDirectory()
+        let url = directory.appendingPathComponent("settings.json")
+        try Data("original".utf8).write(to: url)
+
+        let firstFingerprint = try AtomicFileWriter.fingerprint(at: url)
+        try AtomicFileWriter.write(Data("updated".utf8), to: url, expectedFingerprint: firstFingerprint)
+
+        let backupURL = AtomicFileWriter.backupURL(for: url)
+        XCTAssertEqual(try String(contentsOf: backupURL, encoding: .utf8), "original")
+
+        let secondFingerprint = try AtomicFileWriter.fingerprint(at: url)
+        try AtomicFileWriter.write(Data("newer".utf8), to: url, expectedFingerprint: secondFingerprint)
+
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), "newer")
+        XCTAssertEqual(try String(contentsOf: backupURL, encoding: .utf8), "original")
+        XCTAssertTrue(try temporaryFiles(in: directory).isEmpty)
+    }
+
+    func testExternalChangeFailsAndLeavesCurrentFileUntouched() throws {
+        let directory = try makeTemporaryDirectory()
+        let url = directory.appendingPathComponent("config.toml")
+        try Data("abc".utf8).write(to: url)
+        let fingerprint = try AtomicFileWriter.fingerprint(at: url)
+
+        try Data("xyz".utf8).write(to: url)
+
+        XCTAssertThrowsError(
+            try AtomicFileWriter.write(Data("new".utf8), to: url, expectedFingerprint: fingerprint)
+        ) { error in
+            guard case AtomicFileWriteError.changedExternally(let path) = error else {
+                return XCTFail("expected changedExternally, got \(error)")
+            }
+            XCTAssertEqual(path, url.path)
+        }
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), "xyz")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: AtomicFileWriter.backupURL(for: url).path))
+        XCTAssertTrue(try temporaryFiles(in: directory).isEmpty)
+    }
+
+    func testOverwritePreservesExistingPermissionsWhenNotSpecified() throws {
+        let directory = try makeTemporaryDirectory()
+        let url = directory.appendingPathComponent("settings.json")
+        try Data("old".utf8).write(to: url)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+
+        let fingerprint = try AtomicFileWriter.fingerprint(at: url)
+        try AtomicFileWriter.write(Data("new".utf8), to: url, expectedFingerprint: fingerprint)
+
+        XCTAssertEqual(try permissions(at: url), 0o600)
+    }
+
+    func testExplicitPermissionsApplyToReplacement() throws {
+        let directory = try makeTemporaryDirectory()
+        let url = directory.appendingPathComponent("dynamic-island-hook")
+
+        try AtomicFileWriter.write(Data("binary".utf8), to: url, backupExisting: false, posixPermissions: 0o755)
+
+        XCTAssertEqual(try permissions(at: url), 0o755)
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AtomicFileWriterTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: url)
+        }
+        return url
+    }
+
+    private func temporaryFiles(in directory: URL) throws -> [String] {
+        try FileManager.default.contentsOfDirectory(atPath: directory.path)
+            .filter { $0.hasSuffix(".tmp") }
+    }
+
+    private func permissions(at url: URL) throws -> Int {
+        let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+        let raw = try XCTUnwrap(attrs[.posixPermissions] as? NSNumber)
+        return raw.intValue & 0o777
+    }
+}

--- a/Tests/DynamicIslandCoreTests/ResponseWaiterStoreTests.swift
+++ b/Tests/DynamicIslandCoreTests/ResponseWaiterStoreTests.swift
@@ -137,7 +137,7 @@ final class ResponseWaiterStoreTests: XCTestCase {
             await store.wait(
                 eventID: eventB,
                 timeoutValue: "timeout",
-                timeoutNanoseconds: 5_000_000
+                timeoutNanoseconds: 1_000_000_000
             )
         }
         await waitForWaiters(store, count: 1)


### PR DESCRIPTION
Closes #37.

Summary:
- Add AtomicFileWriter with same-directory temp writes, best-effort fsync, atomic rename, idempotent .bak creation, and external-change fingerprint checks.
- Route HookInstaller settings JSON, Codex config.toml, and deployed hook binary writes through it.
- Cover create, overwrite, backup, external-change, and permission behavior in DynamicIslandCore tests.

Tests:
- swift test