### PR TITLE
refactor(hooks): tighten isOurs to exact-path comparison

### DIFF
--- a/Sources/DynamicIsland/HookInstaller.swift
+++ b/Sources/DynamicIsland/HookInstaller.swift
@@ -407,10 +407,32 @@ enum HookInstaller {
         }
     }
 
+    /// Decide whether a settings entry's `command` string was written by
+    /// us, so we can distinguish our entries from a user's other tooling
+    /// (e.g. gemini-bridge.sh). Strict path comparison after stripping
+    /// env-prefix and shell quotes — substring matching like the older
+    /// implementation could pick up unrelated paths that happened to
+    /// contain `dynamic-island-hook` or the very generic `DynamicIsland`
+    /// substring.
     private static func isOurs(commandPath: String) -> Bool {
-        let markers = ["dynamic-island-hook", "island-hook.sh", "claude-hook.sh", "DynamicIsland"]
-        return markers.contains { commandPath.contains($0) }
+        Self.knownOwnedHookPaths.contains(stripCommandPrefix(commandPath))
     }
+
+    /// Canonical set of hook-binary paths we ever owned, across all
+    /// supported targets and historical layouts. Anything outside this
+    /// set is somebody else's hook and must be left alone.
+    private static let knownOwnedHookPaths: Set<String> = {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return [
+            // Current — Swift binary, deployed by `deployHookScript`
+            "\(home)/.claude/hooks/dynamic-island-hook",
+            "\(home)/.copilot/hooks/dynamic-island-hook",
+            "\(home)/.codex/hooks/dynamic-island-hook",
+            // Pre-v1.5 — bash script with `jq`
+            "\(home)/.claude/hooks/island-hook.sh",
+            "\(home)/.claude/hooks/claude-hook.sh",
+        ]
+    }()
 
     struct SettingsParseError: LocalizedError {
         let path: String

--- a/Sources/DynamicIsland/HookInstaller.swift
+++ b/Sources/DynamicIsland/HookInstaller.swift
@@ -421,17 +421,27 @@ enum HookInstaller {
     /// Canonical set of hook-binary paths we ever owned, across all
     /// supported targets and historical layouts. Anything outside this
     /// set is somebody else's hook and must be left alone.
+    ///
+    /// Current-binary paths are sourced from `Target.deployedHookURL`
+    /// directly so a future relayout of one of those paths can't drift
+    /// out of sync with the ownership check. Legacy bash paths from
+    /// pre-v1.5 are kept as literals — they're frozen, not derived.
     private static let knownOwnedHookPaths: Set<String> = {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
-        return [
-            // Current — Swift binary, deployed by `deployHookScript`
-            "\(home)/.claude/hooks/dynamic-island-hook",
-            "\(home)/.copilot/hooks/dynamic-island-hook",
-            "\(home)/.codex/hooks/dynamic-island-hook",
-            // Pre-v1.5 — bash script with `jq`
+        // Copilot's `deployedHookURL` ignores its associated repoPath
+        // (the binary lives globally, each repo's config just references
+        // it). Pass a placeholder URL just to construct the case.
+        let copilotPlaceholder = URL(fileURLWithPath: "/")
+        let current = [
+            Target.claudeCode.deployedHookURL.path,
+            Target.copilot(repoPath: copilotPlaceholder).deployedHookURL.path,
+            Target.codex.deployedHookURL.path,
+        ]
+        let legacy = [
             "\(home)/.claude/hooks/island-hook.sh",
             "\(home)/.claude/hooks/claude-hook.sh",
         ]
+        return Set(current + legacy)
     }()
 
     struct SettingsParseError: LocalizedError {

--- a/Sources/DynamicIslandCore/HookCommandParse.swift
+++ b/Sources/DynamicIslandCore/HookCommandParse.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Strip `KEY=value` env prefixes and surrounding shell quotes from a
+/// hook `command` string, leaving the bare executable path.
+///
+/// Settings files store the command as a single string with optional
+/// env-var prefixes injected by `HookInstaller.commandString` and the
+/// path shell-quoted to survive whitespace. To compare two such strings
+/// for "are they pointing at the same binary", we need a canonical
+/// form. Examples:
+///
+///     /Users/foo/.claude/hooks/dynamic-island-hook
+///     '/Users/foo/.claude/hooks/dynamic-island-hook'
+///     CC_ISLAND_STOP_TIMEOUT=30 '/Users/foo/.claude/hooks/dynamic-island-hook'
+///     CC_ISLAND_INLINE_REPLY=1 CC_ISLAND_STOP_TIMEOUT=30 '/Users/foo/.claude/hooks/dynamic-island-hook'
+///     ISLAND_SOURCE=codex '/Users/foo/.codex/hooks/dynamic-island-hook'
+///
+/// All five collapse to the bare path. Pure — no I/O.
+public func stripCommandPrefix(_ command: String) -> String {
+    let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+    // Match a leading sequence of `KEY=value ` pairs. Both KEY and value
+    // are non-space; values aren't expected to contain whitespace
+    // (they're env vars set by the installer like `1` / `30` / `codex`).
+    let envPrefix = #"^(?:[A-Z_][A-Z0-9_]*=\S+\s+)+"#
+    let withoutEnv: String
+    if let range = trimmed.range(of: envPrefix, options: .regularExpression) {
+        withoutEnv = String(trimmed[range.upperBound...])
+    } else {
+        withoutEnv = trimmed
+    }
+    return stripQuotes(withoutEnv)
+}
+
+/// Strip a single matching pair of leading/trailing `'` or `"` quotes.
+private func stripQuotes(_ s: String) -> String {
+    guard s.count >= 2 else { return s }
+    let first = s.first!
+    let last = s.last!
+    if (first == "'" && last == "'") || (first == "\"" && last == "\"") {
+        return String(s.dropFirst().dropLast())
+    }
+    return s
+}

--- a/Tests/DynamicIslandCoreTests/HookCommandParseTests.swift
+++ b/Tests/DynamicIslandCoreTests/HookCommandParseTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import DynamicIslandCore
+
+final class HookCommandParseTests: XCTestCase {
+
+    // MARK: - Bare path passthrough
+
+    func testBarePath_returnsAsIs() {
+        XCTAssertEqual(
+            stripCommandPrefix("/Users/foo/.claude/hooks/dynamic-island-hook"),
+            "/Users/foo/.claude/hooks/dynamic-island-hook"
+        )
+    }
+
+    // MARK: - Quote stripping
+
+    func testSingleQuoted_stripsOuterQuotes() {
+        XCTAssertEqual(
+            stripCommandPrefix("'/Users/foo/.claude/hooks/dynamic-island-hook'"),
+            "/Users/foo/.claude/hooks/dynamic-island-hook"
+        )
+    }
+
+    func testDoubleQuoted_stripsOuterQuotes() {
+        XCTAssertEqual(
+            stripCommandPrefix(#""/Users/foo/.claude/hooks/dynamic-island-hook""#),
+            "/Users/foo/.claude/hooks/dynamic-island-hook"
+        )
+    }
+
+    func testMismatchedQuotes_passesThrough() {
+        // Don't try to be clever — leave malformed strings alone so a
+        // matching test against a known-canonical path simply fails.
+        XCTAssertEqual(
+            stripCommandPrefix("'/path/no-trailing-quote"),
+            "'/path/no-trailing-quote"
+        )
+    }
+
+    // MARK: - Env prefix stripping
+
+    func testSingleEnvPrefix_stripped() {
+        XCTAssertEqual(
+            stripCommandPrefix("CC_ISLAND_STOP_TIMEOUT=30 '/Users/foo/.claude/hooks/dynamic-island-hook'"),
+            "/Users/foo/.claude/hooks/dynamic-island-hook"
+        )
+    }
+
+    func testMultipleEnvPrefixes_allStripped() {
+        XCTAssertEqual(
+            stripCommandPrefix("CC_ISLAND_INLINE_REPLY=1 CC_ISLAND_STOP_TIMEOUT=30 '/Users/foo/.claude/hooks/dynamic-island-hook'"),
+            "/Users/foo/.claude/hooks/dynamic-island-hook"
+        )
+    }
+
+    func testCodexSourcePrefix_stripped() {
+        XCTAssertEqual(
+            stripCommandPrefix("ISLAND_SOURCE=codex '/Users/foo/.codex/hooks/dynamic-island-hook'"),
+            "/Users/foo/.codex/hooks/dynamic-island-hook"
+        )
+    }
+
+    func testEnvPrefixWithoutQuotes() {
+        XCTAssertEqual(
+            stripCommandPrefix("CC_ISLAND_STOP_TIMEOUT=30 /Users/foo/.claude/hooks/dynamic-island-hook"),
+            "/Users/foo/.claude/hooks/dynamic-island-hook"
+        )
+    }
+
+    // MARK: - Negative matches: no env, just path
+
+    func testLowercaseAtStart_notTreatedAsEnv() {
+        // env keys must start uppercase per POSIX convention; a
+        // lowercase token at the start is part of the path.
+        XCTAssertEqual(
+            stripCommandPrefix("/usr/local/bin/hook"),
+            "/usr/local/bin/hook"
+        )
+    }
+
+    func testNoEnvPrefixWhenNoEqualsSign() {
+        XCTAssertEqual(
+            stripCommandPrefix("just /usr/local/bin/hook"),
+            "just /usr/local/bin/hook"
+        )
+    }
+
+    // MARK: - Whitespace handling
+
+    func testLeadingTrailingWhitespace_trimmed() {
+        XCTAssertEqual(
+            stripCommandPrefix("   '/path/hook'   "),
+            "/path/hook"
+        )
+    }
+}


### PR DESCRIPTION
README backlog item — tighten hook ownership detection.

## Summary

`HookInstaller.isOurs` decides whether a settings entry's
`command` string was written by us. Previously: substring match
against `["dynamic-island-hook", "island-hook.sh",
"claude-hook.sh", "DynamicIsland"]`. The `DynamicIsland`
substring in particular is generic enough to catch unrelated
hooks whose path happens to contain it.

This PR replaces the substring check with **strict equality
against a `knownOwnedHookPaths` set**, after stripping the
settings entry's env-var prefixes (`CC_ISLAND_*`, `ISLAND_SOURCE`)
and surrounding shell quotes via a new pure helper
`stripCommandPrefix(_:)`.

## What this PR does

### `Sources/DynamicIslandCore/HookCommandParse.swift` (new)

Pure function `stripCommandPrefix(_:)`. Strips a leading sequence
of `KEY=value` env prefixes via regex (`[A-Z_][A-Z0-9_]*=\S+\s+`),
then strips a single matching outer pair of `'...'` or `"..."`
quotes. Trims whitespace.

### `Tests/DynamicIslandCoreTests/HookCommandParseTests.swift` (new)

11 cases covering: bare path, single/double quotes, mismatched
quote pass-through, single env prefix, multi env prefix,
`ISLAND_SOURCE=codex`, env without quotes, lowercase-not-env,
non-env whitespace pass-through, and leading/trailing whitespace.

### `Sources/DynamicIsland/HookInstaller.swift`

`isOurs` now stripped + compared against the known set. The
generic `"DynamicIsland"` substring marker is removed (it could
match unrelated paths). `island-hook.sh` and `claude-hook.sh`
are kept as known legacy paths so pre-v1.5 installs still
migrate cleanly.

## Test plan

- [x] `swift test`: 147 → **158 tests**, 0 failures.
- [x] Mechanical: a coexisting `~/.claude/settings.json` entry for
  `gemini-bridge.sh` is left untouched on reinstall.
- [x] Mechanical: our deployed hook entry is still detected as
  ours; `currentlyInSync == true` after a no-op reinstall.

## Out of scope

- Migrating away from substring-based `currentlyInSync` byte-
  compare for the full command string — that's a separate
  question; this PR just tightens the per-entry "is this row
  one of ours" check.