### PR TITLE
refactor(hook): move PreToolUse cache from /tmp to ~/Library/Caches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ The matcher in `settings.json` intentionally limits `PermissionRequest` to risky
 
 ### FIFO context correlation
 
-`PreToolUse` for Edit/Write/Bash/MultiEdit/NotebookEdit caches its full payload to `/tmp/di_pretool_${PROJECT}.json`. The next `PermissionRequest` reads it to enrich the dialog: Edit/MultiEdit shows a colored diff (red `-` / green `+`), Write shows a content preview, Bash backfills the command/description if `tool_input` arrived empty. Keyed by project name, single-slot (the next PreToolUse overwrites) — works because PreToolUse and PermissionRequest fire serially per Claude session.
+`PreToolUse` for Edit/Write/Bash/MultiEdit/NotebookEdit caches its full payload under `~/Library/Caches/cc-island/pretool/<key>.json`. The next `PermissionRequest` reads it to enrich the dialog: Edit/MultiEdit shows a colored diff (red `-` / green `+`), Write shows a content preview, Bash backfills the command/description if `tool_input` arrived empty. Single-slot per key (the next PreToolUse overwrites) — works because PreToolUse and PermissionRequest fire serially per session. Key resolves via `IslandHookCore.preToolCacheKey`: `session_id` first, then `agent-<agentId>-<project>` for subagents, then `<project>`, then `default`. Pre-v1.7.x layout was `/tmp/di_pretool_${PROJECT}.json` — the old path is world-readable on multi-user machines and predictable across processes, so the cache moved into the per-user `~/Library/Caches/` tree.
 
 ## Conventions
 

--- a/Sources/IslandHookCore/HookPlan.swift
+++ b/Sources/IslandHookCore/HookPlan.swift
@@ -12,6 +12,11 @@ public struct HookPlan {
     public let displayProject: String   // project OR "↳ agent_type" for subagents
     public let agentId: String?
     public let agentType: String?
+    /// Claude Code session UUID from the hook payload (`session_id`).
+    /// Used to scope the PreToolUse → PermissionRequest context cache
+    /// per session so two parallel sessions in the same project don't
+    /// clobber each other's cached `tool_input`.
+    public let sessionID: String?
     public let toolInput: [String: Any]
     public let copilotToolArgs: [String: Any]
     public let cpError: String?         // Copilot .error.message for Error events
@@ -33,6 +38,7 @@ public struct HookPlan {
         payload: [String: Any], source: String, event: String, tool: String,
         cwd: String, project: String, displayProject: String,
         agentId: String?, agentType: String?,
+        sessionID: String? = nil,
         toolInput: [String: Any], copilotToolArgs: [String: Any],
         cpError: String?,
         inlineReplyEnabled: Bool = false,
@@ -47,6 +53,7 @@ public struct HookPlan {
         self.displayProject = displayProject
         self.agentId = agentId
         self.agentType = agentType
+        self.sessionID = sessionID
         self.toolInput = toolInput
         self.copilotToolArgs = copilotToolArgs
         self.cpError = cpError
@@ -117,6 +124,7 @@ public func parseHookPlan(payload: [String: Any], env: [String: String] = [:]) -
     let project = cwd.isEmpty ? "" : (cwd as NSString).lastPathComponent
     let agentId = payload["agent_id"] as? String
     let agentType = payload["agent_type"] as? String
+    let sessionID = payload["session_id"] as? String
     let hasAgent = !(agentId ?? "").isEmpty && !(agentType ?? "").isEmpty
     let displayProject = hasAgent ? "↳ \(agentType!)" : project
 
@@ -147,6 +155,7 @@ public func parseHookPlan(payload: [String: Any], env: [String: String] = [:]) -
         payload: payload, source: source, event: event, tool: tool,
         cwd: cwd, project: project, displayProject: displayProject,
         agentId: agentId, agentType: agentType,
+        sessionID: sessionID,
         toolInput: toolInput, copilotToolArgs: copilotToolArgs,
         cpError: cpError,
         inlineReplyEnabled: env["CC_ISLAND_INLINE_REPLY"] == "1",

--- a/Sources/IslandHookCore/PreToolCache.swift
+++ b/Sources/IslandHookCore/PreToolCache.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Single-slot context cache that lets `PermissionRequest` enrich its
+/// dialog with the `tool_input` from the immediately preceding
+/// `PreToolUse` (FIFO context correlation). Two pure helpers compute
+/// the cache *key* and *URL*; actual file I/O lives in `island-hook`.
+///
+/// Pre-#5x layout was `/tmp/di_pretool_<project>.json` keyed by
+/// project basename. `/tmp` is world-readable on a multi-user machine
+/// and the path is predictable, so a co-tenant could plant a payload
+/// our `PermissionRequest` would happily read. The new home is the
+/// per-user `~/Library/Caches/cc-island/pretool/`, which inherits user
+/// permissions, plus a stronger key that distinguishes parallel
+/// sessions in the same project.
+
+/// Pick a cache filename stem for the current hook invocation.
+///
+/// Resolution order:
+/// 1. `session_id` (Claude Code's session UUID) — most precise.
+/// 2. `agent-<agentId>-<sanitised-project>` — for subagent runs that
+///    don't carry `session_id` from the host.
+/// 3. `<sanitised-project>` — legacy / non-Claude callers.
+/// 4. `default` — payload had no project at all.
+public func preToolCacheKey(plan: HookPlan) -> String {
+    if let sid = plan.sessionID, !sid.isEmpty {
+        return sanitiseCacheKey(sid)
+    }
+    if let agentId = plan.agentId, !agentId.isEmpty {
+        return sanitiseCacheKey("agent-\(agentId)-\(plan.project.isEmpty ? "default" : plan.project)")
+    }
+    if !plan.project.isEmpty {
+        return sanitiseCacheKey(plan.project)
+    }
+    return "default"
+}
+
+/// Build the on-disk path for a given cache key. `cachesDirectory`
+/// defaults to the user's `~/Library/Caches`; tests pass a temporary
+/// directory so they don't touch the real cache.
+public func preToolCacheURL(
+    key: String,
+    cachesDirectory: URL = FileManager.default
+        .urls(for: .cachesDirectory, in: .userDomainMask)
+        .first ?? URL(fileURLWithPath: NSTemporaryDirectory())
+) -> URL {
+    cachesDirectory
+        .appendingPathComponent("cc-island", isDirectory: true)
+        .appendingPathComponent("pretool", isDirectory: true)
+        .appendingPathComponent("\(key).json")
+}
+
+/// Replace any character that's awkward inside a filename (path
+/// separators, shell metas, whitespace) with `_`. Pure — no fancy
+/// percent-encoding so the resulting filename stays readable for
+/// debugging.
+public func sanitiseCacheKey(_ raw: String) -> String {
+    let unsafe: Set<Character> = ["/", "\\", ":", "?", "<", ">", "|", "*", "\"", " ", "\t", "\n"]
+    var out = ""
+    out.reserveCapacity(raw.count)
+    for ch in raw {
+        out.append(unsafe.contains(ch) ? "_" : ch)
+    }
+    return out.isEmpty ? "default" : out
+}

--- a/Sources/island-hook/main.swift
+++ b/Sources/island-hook/main.swift
@@ -81,14 +81,22 @@ func longPollResponse(timeoutSeconds: TimeInterval) -> PermissionDecision {
 
 // MARK: - FIFO context cache
 
-let contextFile = "/tmp/di_pretool_\(plan.project.isEmpty ? "default" : plan.project).json"
+// Per-user cache instead of `/tmp/di_pretool_<project>.json`. Keyed
+// by `session_id` (Claude) → `agent-<id>-<project>` → `<project>` →
+// `default`, so two parallel sessions in the same project don't
+// overwrite each other's context. See `IslandHookCore.PreToolCache`.
+let contextURL = preToolCacheURL(key: preToolCacheKey(plan: plan))
 
 func writeContextCache() {
-    try? inputData.write(to: URL(fileURLWithPath: contextFile))
+    try? FileManager.default.createDirectory(
+        at: contextURL.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+    )
+    try? inputData.write(to: contextURL)
 }
 
 func readCachedToolInput() -> (toolName: String, input: [String: Any])? {
-    guard let data = try? Data(contentsOf: URL(fileURLWithPath: contextFile)),
+    guard let data = try? Data(contentsOf: contextURL),
           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
         return nil
     }

--- a/Sources/island-hook/main.swift
+++ b/Sources/island-hook/main.swift
@@ -92,7 +92,10 @@ func writeContextCache() {
         at: contextURL.deletingLastPathComponent(),
         withIntermediateDirectories: true
     )
-    try? inputData.write(to: contextURL)
+    // .atomic so a process crash mid-write can't leave a truncated
+    // JSON for the next PermissionRequest to read. Single-slot cache,
+    // worst case the previous payload survives — never a half one.
+    try? inputData.write(to: contextURL, options: [.atomic])
 }
 
 func readCachedToolInput() -> (toolName: String, input: [String: Any])? {

--- a/Tests/IslandHookCoreTests/PreToolCacheTests.swift
+++ b/Tests/IslandHookCoreTests/PreToolCacheTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+@testable import IslandHookCore
+
+final class PreToolCacheTests: XCTestCase {
+
+    // MARK: - preToolCacheKey
+
+    func testKey_prefersSessionID() {
+        let plan = makePlan(sessionID: "abc-123", agentId: "ag-1", project: "demo")
+        XCTAssertEqual(preToolCacheKey(plan: plan), "abc-123")
+    }
+
+    func testKey_fallsBackToAgentAndProjectWhenNoSessionID() {
+        let plan = makePlan(sessionID: nil, agentId: "ag-1", project: "demo")
+        XCTAssertEqual(preToolCacheKey(plan: plan), "agent-ag-1-demo")
+    }
+
+    func testKey_fallsBackToProjectWhenNoSessionOrAgent() {
+        let plan = makePlan(sessionID: nil, agentId: nil, project: "demo")
+        XCTAssertEqual(preToolCacheKey(plan: plan), "demo")
+    }
+
+    func testKey_defaultWhenNothing() {
+        let plan = makePlan(sessionID: nil, agentId: nil, project: "")
+        XCTAssertEqual(preToolCacheKey(plan: plan), "default")
+    }
+
+    func testKey_emptySessionIDFallsThrough() {
+        // An empty session_id is treated as "no session" — fall through
+        // to agent-based or project-based key.
+        let plan = makePlan(sessionID: "", agentId: nil, project: "demo")
+        XCTAssertEqual(preToolCacheKey(plan: plan), "demo")
+    }
+
+    func testKey_emptyAgentIdFallsThrough() {
+        let plan = makePlan(sessionID: nil, agentId: "", project: "demo")
+        XCTAssertEqual(preToolCacheKey(plan: plan), "demo")
+    }
+
+    // MARK: - sanitiseCacheKey
+
+    func testSanitise_passthroughForSafeKey() {
+        XCTAssertEqual(sanitiseCacheKey("abc-123_demo"), "abc-123_demo")
+    }
+
+    func testSanitise_replacesPathSeparatorsAndMetas() {
+        XCTAssertEqual(
+            sanitiseCacheKey("a/b\\c:d?e<f>g|h*i\"j"),
+            "a_b_c_d_e_f_g_h_i_j"
+        )
+    }
+
+    func testSanitise_replacesWhitespace() {
+        XCTAssertEqual(sanitiseCacheKey("foo bar\tbaz"), "foo_bar_baz")
+    }
+
+    func testSanitise_emptyBecomesDefault() {
+        XCTAssertEqual(sanitiseCacheKey(""), "default")
+    }
+
+    // MARK: - preToolCacheURL
+
+    func testURL_underProvidedCachesDirectory() {
+        let temp = URL(fileURLWithPath: "/tmp/test-cache-base")
+        let url = preToolCacheURL(key: "session-xyz", cachesDirectory: temp)
+        XCTAssertEqual(
+            url.path,
+            "/tmp/test-cache-base/cc-island/pretool/session-xyz.json"
+        )
+    }
+
+    func testURL_defaultRoutesUnderCcIslandPretool() {
+        // Default uses `.cachesDirectory` which on macOS is
+        // `~/Library/Caches`. We only assert the suffix shape so
+        // sandboxed / non-sandboxed builds both pass.
+        let url = preToolCacheURL(key: "k")
+        XCTAssertTrue(
+            url.path.hasSuffix("/cc-island/pretool/k.json"),
+            "unexpected path: \(url.path)"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func makePlan(
+        sessionID: String?,
+        agentId: String?,
+        project: String
+    ) -> HookPlan {
+        HookPlan(
+            payload: [:], source: "claude", event: "PreToolUse", tool: "Edit",
+            cwd: "/tmp", project: project, displayProject: project,
+            agentId: agentId, agentType: agentId == nil ? nil : "general",
+            sessionID: sessionID,
+            toolInput: [:], copilotToolArgs: [:],
+            cpError: nil
+        )
+    }
+}

--- a/Tests/IslandHookCoreTests/PreToolCacheTests.swift
+++ b/Tests/IslandHookCoreTests/PreToolCacheTests.swift
@@ -37,6 +37,23 @@ final class PreToolCacheTests: XCTestCase {
         XCTAssertEqual(preToolCacheKey(plan: plan), "demo")
     }
 
+    func testKey_sanitisesUnsafeProjectName() {
+        // Path separators in project name (e.g. someone passing the
+        // full cwd through) shouldn't escape the pretool/ directory.
+        let plan = makePlan(sessionID: nil, agentId: nil, project: "foo/bar")
+        XCTAssertEqual(preToolCacheKey(plan: plan), "foo_bar")
+    }
+
+    func testKey_sanitisesAgentBranchInputs() {
+        let plan = makePlan(sessionID: nil, agentId: "ag/1", project: "demo space")
+        XCTAssertEqual(preToolCacheKey(plan: plan), "agent-ag_1-demo_space")
+    }
+
+    func testKey_sanitisesSessionIDPath() {
+        let plan = makePlan(sessionID: "sess/with/slash", agentId: nil, project: "demo")
+        XCTAssertEqual(preToolCacheKey(plan: plan), "sess_with_slash")
+    }
+
     // MARK: - sanitiseCacheKey
 
     func testSanitise_passthroughForSafeKey() {


### PR DESCRIPTION
README backlog item — move PreToolUse cache out of predictable
`/tmp` path.

## Why

The PreToolUse → PermissionRequest context cache has been writing
to `/tmp/di_pretool_<project>.json` since v1.5. On a multi-user
machine that's:

- World-readable — anyone logged in can read another user's
  pending tool input + cwd.
- Predictable by project name — a co-tenant could plant a payload
  at the same path before our PreToolUse writes; the next
  PermissionRequest would read it as enrichment context.

Low-impact (the cache only feeds a UI preview), but a bad default.

## What

- New cache root: `~/Library/Caches/cc-island/pretool/<key>.json`
  (per-user, inherits home permissions).
- New key: `session_id` first, fallback to `agent-<agentId>-<project>`,
  then `<project>`, then `default`. Two parallel Claude sessions
  in the same project no longer clobber each other.
- Path / key construction extracted to pure helpers in
  `IslandHookCore.PreToolCache` so the logic is unit-testable
  without I/O.
- `HookPlan.sessionID: String?` added (mirrors `agentId`),
  parsed from `payload["session_id"]`.
- `island-hook/main.swift` `writeContextCache` now `mkdir -p`s
  the parent before writing.

## Tests

`PreToolCacheTests.swift` (new) — 12 cases:
- Key priority: sessionID > agent-project > project > default.
- Empty sessionID / agentId fall through correctly.
- Sanitiser: safe-key passthrough, path-sep / shell-meta /
  whitespace replacement, empty → `default`.
- URL: under provided caches dir, suffix shape under default.

`swift test`: 158 → **170 tests**, 0 failures.

## Mechanical smoke

Piped a PreToolUse payload with `session_id: test-session-uuid-aaa`
into the deployed hook. Cache landed at
`~/Library/Caches/cc-island/pretool/test-session-uuid-aaa.json`;
no new `/tmp/di_pretool_*` file written.

## Migration

Old `/tmp/di_pretool_*.json` files don't migrate — they're
transient, single-slot per session, and the OS clears `/tmp` on
reboot anyway. After upgrading the binary the first PreToolUse
writes to the new location and PermissionRequest reads from the
same place.

CLAUDE.md updated to describe the new layout.