### PR TITLE
feat(settings): Appearance + Hooks tabs

### DIFF
--- a/Sources/DynamicIsland/App.swift
+++ b/Sources/DynamicIsland/App.swift
@@ -124,6 +124,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         dynamicIslandUserDefaults.register(defaults: [
             stopReplyTimeoutKey: StopReplyTimeoutSeconds,
             screenFollowerDwellKey: 200.0,
+            // #45: source colours, default to today's hardcoded palette
+            claudeColorHexKey: defaultClaudeColorHex,
+            copilotColorHexKey: defaultCopilotColorHex,
+            codexColorHexKey: defaultCodexColorHex,
+            // #45: per-provider auto-sync at launch. Defaults match
+            // pre-#45 behaviour (Claude on, Codex on, Copilot off).
+            autoSyncClaudeKey: true,
+            autoSyncCodexKey: true,
+            autoSyncCopilotKey: false,
         ])
 
         panel = IslandPanel(stateManager: stateManager)
@@ -191,15 +200,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         settings.keyEquivalentModifierMask = [.command]
         menu.addItem(settings)
         menu.addItem(.separator())
-        menu.addItem(NSMenuItem(
-            title: "Reinstall Claude Code Hooks",
-            action: #selector(reinstallHooks),
-            keyEquivalent: ""))
-        menu.addItem(NSMenuItem(
-            title: "Reinstall Codex Hooks",
-            action: #selector(reinstallCodexHooks),
-            keyEquivalent: ""))
-        menu.addItem(.separator())
         let quit = NSMenuItem(
             title: "Quit Dynamic Island",
             action: #selector(NSApplication.terminate(_:)),
@@ -244,33 +244,26 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         settingsWindowController?.present()
     }
 
-    @objc private func reinstallHooks() {
-        let result = HookInstaller.install(target: .claudeCode)
-        reportInstallResult(result, target: .claudeCode)
-        if case .installed = result {
-            UserDefaults.standard.set("installed", forKey: Self.hookChoiceKey)
-        }
-    }
-
-    @objc private func reinstallCodexHooks() {
-        let result = HookInstaller.install(target: .codex)
-        reportInstallResult(result, target: .codex)
-    }
-
     private func maybePromptForHookInstall() {
         switch UserDefaults.standard.string(forKey: Self.hookChoiceKey) {
         case "installed":
-            _ = HookInstaller.syncIfOutdated(target: .claudeCode)
+            // #45: gate the launch-time sync behind the per-provider
+            // auto-sync UserDefault so a user can opt out from the
+            // Settings panel.
+            if dynamicIslandUserDefaults.bool(forKey: autoSyncClaudeKey) {
+                _ = HookInstaller.syncIfOutdated(target: .claudeCode)
+            }
         case "declined":
             break
         default:
             showInstallPrompt()
         }
 
-        // Codex hooks are installed explicitly via CLI/menu, but once present
-        // they need the same binary drift repair as Claude hooks after app
-        // upgrades.
-        if HookInstaller.hasExistingInstall(target: .codex) {
+        // Codex hooks are installed explicitly via CLI/menu, but once
+        // present they need the same binary drift repair as Claude
+        // hooks after app upgrades. Same per-provider gate.
+        if HookInstaller.hasExistingInstall(target: .codex),
+           dynamicIslandUserDefaults.bool(forKey: autoSyncCodexKey) {
             _ = HookInstaller.syncIfOutdated(target: .codex)
         }
     }

--- a/Sources/DynamicIsland/App.swift
+++ b/Sources/DynamicIsland/App.swift
@@ -113,7 +113,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // on first close and cmd-, would break (#41 review).
     private var settingsWindowController: SettingsWindowController?
 
-    private static let hookChoiceKey = "hookInstallChoice"
+    // hookInstallChoiceKey lives at module scope (HookInstaller.swift)
+    // so SettingsView's HooksTab can share the same string.
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // #41: register UserDefaults defaults so unset reads return the
@@ -245,7 +246,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func maybePromptForHookInstall() {
-        switch UserDefaults.standard.string(forKey: Self.hookChoiceKey) {
+        switch UserDefaults.standard.string(forKey: hookInstallChoiceKey) {
         case "installed":
             // #45: gate the launch-time sync behind the per-provider
             // auto-sync UserDefault so a user can opt out from the
@@ -292,10 +293,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         switch alert.runModal() {
         case .alertFirstButtonReturn:   // Install
             let result = HookInstaller.install(target: .claudeCode)
-            UserDefaults.standard.set("installed", forKey: Self.hookChoiceKey)
+            UserDefaults.standard.set("installed", forKey: hookInstallChoiceKey)
             reportInstallResult(result, target: .claudeCode)
         case .alertThirdButtonReturn:   // Never
-            UserDefaults.standard.set("declined", forKey: Self.hookChoiceKey)
+            UserDefaults.standard.set("declined", forKey: hookInstallChoiceKey)
         default:                        // Skip — ask again next launch
             break
         }

--- a/Sources/DynamicIsland/HookInstaller.swift
+++ b/Sources/DynamicIsland/HookInstaller.swift
@@ -49,6 +49,28 @@ let stopReplyTimeoutKey = "stopReplyTimeoutSeconds"
 /// move. Default `200`.
 let screenFollowerDwellKey = "screenFollowerDwellMilliseconds"
 
+/// UserDefaults keys for the source colour palette (#45). Stored as
+/// `#RRGGBB` hex strings so they survive plist round-trips without a
+/// custom codable adapter. Read by `IslandEvent.sourceColor(_:)` and
+/// bound to `ColorPicker`s in `SettingsView` via a hex/Color binding.
+/// Defaults match the v1.0 hardcoded palette.
+let claudeColorHexKey = "claudeColorHex"
+let copilotColorHexKey = "copilotColorHex"
+let codexColorHexKey = "codexColorHex"
+let defaultClaudeColorHex = "#D9A673"   // warm orange
+let defaultCopilotColorHex = "#A680F2"  // GitHub violet
+let defaultCodexColorHex = "#4CCC99"    // OpenAI green
+
+/// UserDefaults Bool keys for per-provider auto-sync at launch (#45).
+/// Drive whether `applicationDidFinishLaunching` calls
+/// `HookInstaller.syncIfOutdated(target:)` for each target. Defaults
+/// match today's behaviour: Claude on (provided the install prompt
+/// has been answered), Codex on (only if already installed via CLI),
+/// Copilot off (per-repo, no global sync notion).
+let autoSyncClaudeKey = "autoSyncClaudeOnLaunch"
+let autoSyncCopilotKey = "autoSyncCopilotOnLaunch"
+let autoSyncCodexKey = "autoSyncCodexOnLaunch"
+
 /// Read a positive `Double` UserDefault, falling back to `defaultValue`
 /// when the key is unset, malformed, or `<= 0`.
 ///

--- a/Sources/DynamicIsland/HookInstaller.swift
+++ b/Sources/DynamicIsland/HookInstaller.swift
@@ -71,6 +71,14 @@ let autoSyncClaudeKey = "autoSyncClaudeOnLaunch"
 let autoSyncCopilotKey = "autoSyncCopilotOnLaunch"
 let autoSyncCodexKey = "autoSyncCodexOnLaunch"
 
+/// UserDefaults String key for the first-launch install-prompt choice.
+/// Lives on `UserDefaults.standard` (legacy from before
+/// `dynamicIslandUserDefaults` existed). Read by
+/// `AppDelegate.maybePromptForHookInstall`, written by both that path
+/// and `SettingsView.HooksTab` so a manual reinstall counts as
+/// implicit acceptance of the prompt.
+let hookInstallChoiceKey = "hookInstallChoice"
+
 /// Read a positive `Double` UserDefault, falling back to `defaultValue`
 /// when the key is unset, malformed, or `<= 0`.
 ///

--- a/Sources/DynamicIsland/IslandState.swift
+++ b/Sources/DynamicIsland/IslandState.swift
@@ -1,3 +1,4 @@
+import DynamicIslandCore
 import Foundation
 import SwiftUI
 import IslandHookCore
@@ -76,12 +77,17 @@ struct IslandEvent: Identifiable {
     }
 
     static func sourceColor(_ source: String) -> Color? {
+        let key: String
+        let fallback: String
         switch source.lowercased() {
-        case "claude":  return Color(red: 0.85, green: 0.65, blue: 0.45) // warm orange
-        case "copilot": return Color(red: 0.65, green: 0.50, blue: 0.95) // GitHub violet
-        case "codex":   return Color(red: 0.30, green: 0.80, blue: 0.60) // OpenAI green
+        case "claude":  key = claudeColorHexKey;  fallback = defaultClaudeColorHex
+        case "copilot": key = copilotColorHexKey; fallback = defaultCopilotColorHex
+        case "codex":   key = codexColorHexKey;   fallback = defaultCodexColorHex
         default: return nil
         }
+        let hex = dynamicIslandUserDefaults.string(forKey: key) ?? fallback
+        let rgb = parseHexColor(hex) ?? parseHexColor(fallback) ?? RGB(r: 1, g: 1, b: 1)
+        return Color(red: rgb.r, green: rgb.g, blue: rgb.b)
     }
 
     init(

--- a/Sources/DynamicIsland/SettingsView.swift
+++ b/Sources/DynamicIsland/SettingsView.swift
@@ -1,18 +1,38 @@
-import SwiftUI
+import AppKit
+import DynamicIslandCore
 import IslandHookCore
+import SwiftUI
 
-/// First slice of #41 (README roadmap item 11). One "General" tab with:
+/// Settings panel with three tabs (#41, #45):
 ///
-/// - Inline-reply toggle — gates Phase 2 of #20 on the app side.
-///   Hook-side env propagation requires reinstalling Claude Code hooks
-///   (helper text + button below makes this explicit, no implicit
-///   "magic" reinstall on toggle change).
-/// - Stop reply timeout — long-poll horizon on the hook side. Must be
-///   reinstalled to propagate; the same Reinstall button covers it.
-/// - Screen follower dwell — reactive at runtime, no reinstall needed.
+/// - **General** — inline-reply toggle + tunable Stop / dwell timings.
+/// - **Appearance** — source-colour palette (Claude / Copilot / Codex).
+/// - **Hooks** — per-provider auto-sync toggles + reinstall buttons.
+///
+/// All three tabs use `@AppStorage(... store: dynamicIslandUserDefaults)`
+/// for live UI binding. Hook-side propagation (env-var injection into
+/// `~/.claude/settings.json`) requires reinstalling the hooks; the Hooks
+/// tab carries the button.
 struct SettingsView: View {
     @ObservedObject var stateManager: IslandStateManager
 
+    var body: some View {
+        TabView {
+            GeneralTab()
+                .tabItem { Label("General", systemImage: "gearshape") }
+            AppearanceTab()
+                .tabItem { Label("Appearance", systemImage: "paintpalette") }
+            HooksTab()
+                .tabItem { Label("Hooks", systemImage: "link") }
+        }
+        .padding()
+        .frame(minWidth: 480, minHeight: 380)
+    }
+}
+
+// MARK: - General
+
+private struct GeneralTab: View {
     @AppStorage(enableInlineReplyKey, store: dynamicIslandUserDefaults)
     private var inlineReplyEnabled = false
 
@@ -22,17 +42,11 @@ struct SettingsView: View {
     @AppStorage(screenFollowerDwellKey, store: dynamicIslandUserDefaults)
     private var screenFollowerDwellMs: Double = 200
 
-    @State private var reinstallStatus: ReinstallStatus = .idle
-
-    enum ReinstallStatus: Equatable {
-        case idle, installed, alreadyCurrent, failed(String)
-    }
-
     var body: some View {
         Form {
             Section {
                 Toggle("Inline reply for Stop events", isOn: $inlineReplyEnabled)
-                Text("Lets you reply to Claude's free-form questions directly from the island. After toggling, click Reinstall below for the change to reach the hook.")
+                Text("Lets you reply to Claude's free-form questions directly from the island. Toggling this changes the UI immediately, but the hook side only picks it up after reinstalling Claude Code hooks (see Hooks tab).")
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -55,7 +69,7 @@ struct SettingsView: View {
                     Text("seconds")
                         .foregroundColor(.secondary)
                 }
-                Text("How long the island waits for your reply before falling back to Claude's default Stop behaviour. Reinstall hooks for changes to apply.")
+                Text("How long the island waits for your reply before falling back to Claude's default Stop behaviour. Reinstall hooks to apply.")
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -81,30 +95,155 @@ struct SettingsView: View {
             } header: {
                 Text("Timings").font(.headline)
             }
+        }
+        .formStyle(.grouped)
+    }
+}
 
+// MARK: - Appearance
+
+private struct AppearanceTab: View {
+    @AppStorage(claudeColorHexKey, store: dynamicIslandUserDefaults)
+    private var claudeHex = defaultClaudeColorHex
+
+    @AppStorage(copilotColorHexKey, store: dynamicIslandUserDefaults)
+    private var copilotHex = defaultCopilotColorHex
+
+    @AppStorage(codexColorHexKey, store: dynamicIslandUserDefaults)
+    private var codexHex = defaultCodexColorHex
+
+    var body: some View {
+        Form {
             Section {
+                ColorPicker("Claude Code", selection: hexBinding($claudeHex), supportsOpacity: false)
+                ColorPicker("GitHub Copilot", selection: hexBinding($copilotHex), supportsOpacity: false)
+                ColorPicker("OpenAI Codex", selection: hexBinding($codexHex), supportsOpacity: false)
                 HStack {
-                    Button("Reinstall Claude Code Hooks") { reinstall() }
-                    statusLabel
                     Spacer()
+                    Button("Reset to defaults") {
+                        claudeHex = defaultClaudeColorHex
+                        copilotHex = defaultCopilotColorHex
+                        codexHex = defaultCodexColorHex
+                    }
                 }
             } header: {
-                Text("Hooks").font(.headline)
+                Text("Source colours").font(.headline)
             } footer: {
-                Text("Required after toggling Inline reply or changing Stop reply timeout — the values reach the hook process via env vars in the hook command, written into ~/.claude/settings.json on install.")
+                Text("Drives the source-tinted stripe on each ear and the project-source dot. Colour change applies to the next event the island shows.")
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
         .formStyle(.grouped)
-        .padding()
-        .frame(minWidth: 460, minHeight: 340)
+    }
+}
+
+/// Adapter — exposes a `@Binding<String>` (a `#RRGGBB` hex stored in
+/// UserDefaults) as a `Binding<Color>` so SwiftUI's `ColorPicker` can
+/// drive it directly. Round-trips through sRGB component extraction
+/// via `NSColor` so non-sRGB picks (e.g. `Display P3` from the
+/// system colour panel) flatten cleanly.
+private func hexBinding(_ source: Binding<String>) -> Binding<Color> {
+    Binding<Color>(
+        get: {
+            let rgb = parseHexColor(source.wrappedValue) ?? RGB(r: 1, g: 1, b: 1)
+            return Color(red: rgb.r, green: rgb.g, blue: rgb.b)
+        },
+        set: { newColor in
+            let ns = NSColor(newColor).usingColorSpace(.sRGB) ?? NSColor.white
+            let rgb = RGB(
+                r: Double(ns.redComponent),
+                g: Double(ns.greenComponent),
+                b: Double(ns.blueComponent)
+            )
+            source.wrappedValue = encodeHexColor(rgb)
+        }
+    )
+}
+
+// MARK: - Hooks
+
+private struct HooksTab: View {
+    @AppStorage(autoSyncClaudeKey, store: dynamicIslandUserDefaults)
+    private var autoSyncClaude = true
+
+    @AppStorage(autoSyncCodexKey, store: dynamicIslandUserDefaults)
+    private var autoSyncCodex = true
+
+    @State private var claudeStatus = ReinstallStatus.idle
+    @State private var codexStatus = ReinstallStatus.idle
+
+    enum ReinstallStatus: Equatable {
+        case idle, installed, alreadyCurrent, failed(String)
+    }
+
+    var body: some View {
+        Form {
+            claudeSection
+            codexSection
+            copilotSection
+        }
+        .formStyle(.grouped)
     }
 
     @ViewBuilder
-    private var statusLabel: some View {
-        switch reinstallStatus {
+    private var claudeSection: some View {
+        Section {
+            Toggle("Auto-sync at launch", isOn: $autoSyncClaude)
+            Text("Re-deploys the hook binary if the bundled version changed. Off skips the launch-time check; you can still reinstall here on demand.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            HStack {
+                Button("Reinstall Claude Code Hooks") {
+                    claudeStatus = doReinstall(target: .claudeCode, isClaude: true)
+                }
+                statusLabel(claudeStatus)
+            }
+        } header: {
+            Text("Claude Code").font(.headline)
+        }
+    }
+
+    @ViewBuilder
+    private var codexSection: some View {
+        Section {
+            Toggle("Auto-sync at launch", isOn: $autoSyncCodex)
+            Text("Only takes effect once Codex hooks have been installed (CLI: `--install-codex-hooks`). With sync on, the deployed binary is refreshed on each app launch.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            HStack {
+                Button("Reinstall Codex Hooks") {
+                    codexStatus = doReinstall(target: .codex, isClaude: false)
+                }
+                statusLabel(codexStatus)
+            }
+        } header: {
+            Text("Codex").font(.headline)
+        }
+    }
+
+    @ViewBuilder
+    private var copilotSection: some View {
+        Section {
+            Text("Copilot hooks are scoped to a single repository. Install or update from Terminal:")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Text("DynamicIsland --install-copilot-hooks <repo-path>")
+                .font(.system(.caption, design: .monospaced))
+                .textSelection(.enabled)
+                .padding(.vertical, 2)
+        } header: {
+            Text("Copilot").font(.headline)
+        }
+    }
+
+    @ViewBuilder
+    private func statusLabel(_ status: ReinstallStatus) -> some View {
+        switch status {
         case .idle:
             EmptyView()
         case .installed:
@@ -123,19 +262,21 @@ struct SettingsView: View {
         }
     }
 
-    private func reinstall() {
-        let result = HookInstaller.install(target: .claudeCode)
+    /// Fire `HookInstaller.install` and translate to a status enum. For
+    /// Claude, also flip the legacy `hookInstallChoice` UserDefault to
+    /// `installed` so the next launch's prompt path stays consistent
+    /// with what the user just confirmed via this button.
+    private func doReinstall(target: HookInstaller.Target, isClaude: Bool) -> ReinstallStatus {
+        let result = HookInstaller.install(target: target)
+        if isClaude, case .installed = result {
+            UserDefaults.standard.set("installed", forKey: "hookInstallChoice")
+        }
         switch result {
-        case .installed:
-            reinstallStatus = .installed
-        case .alreadyCurrent:
-            reinstallStatus = .alreadyCurrent
-        case .failed(let reason):
-            reinstallStatus = .failed(reason)
-        case .skipped(let message):
-            reinstallStatus = .failed(message)
-        case .removed, .notInstalled:
-            reinstallStatus = .idle
+        case .installed: return .installed
+        case .alreadyCurrent: return .alreadyCurrent
+        case .failed(let reason): return .failed(reason)
+        case .skipped(let message): return .failed(message)
+        case .removed, .notInstalled: return .idle
         }
     }
 }

--- a/Sources/DynamicIsland/SettingsView.swift
+++ b/Sources/DynamicIsland/SettingsView.swift
@@ -26,7 +26,7 @@ struct SettingsView: View {
                 .tabItem { Label("Hooks", systemImage: "link") }
         }
         .padding()
-        .frame(minWidth: 480, minHeight: 380)
+        .frame(minWidth: 480, minHeight: 440)
     }
 }
 
@@ -269,7 +269,7 @@ private struct HooksTab: View {
     private func doReinstall(target: HookInstaller.Target, isClaude: Bool) -> ReinstallStatus {
         let result = HookInstaller.install(target: target)
         if isClaude, case .installed = result {
-            UserDefaults.standard.set("installed", forKey: "hookInstallChoice")
+            UserDefaults.standard.set("installed", forKey: hookInstallChoiceKey)
         }
         switch result {
         case .installed: return .installed

--- a/Sources/DynamicIsland/SettingsWindowController.swift
+++ b/Sources/DynamicIsland/SettingsWindowController.swift
@@ -16,7 +16,7 @@ final class SettingsWindowController: NSWindowController {
         window.title = "Settings"
         window.styleMask = [.titled, .closable, .miniaturizable]
         window.isReleasedWhenClosed = false
-        window.setContentSize(NSSize(width: 480, height: 360))
+        window.setContentSize(NSSize(width: 480, height: 440))
         window.center()
         return SettingsWindowController(window: window)
     }

--- a/Sources/DynamicIslandCore/HexColor.swift
+++ b/Sources/DynamicIslandCore/HexColor.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Parsed sRGB triplet. Components are normalised `0...1` like
+/// SwiftUI's `Color(red:green:blue:)`.
+public struct RGB: Equatable, Sendable {
+    public let r: Double
+    public let g: Double
+    public let b: Double
+
+    public init(r: Double, g: Double, b: Double) {
+        self.r = r
+        self.g = g
+        self.b = b
+    }
+}
+
+/// Parse a 6-digit hex colour string (with or without leading `#`)
+/// into an sRGB triplet. Returns `nil` for any other shape so callers
+/// can fall back to a default rather than render a misleading colour.
+public func parseHexColor(_ raw: String) -> RGB? {
+    var s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    if s.hasPrefix("#") { s.removeFirst() }
+    guard s.count == 6, let v = UInt32(s, radix: 16) else { return nil }
+    return RGB(
+        r: Double((v >> 16) & 0xFF) / 255.0,
+        g: Double((v >> 8) & 0xFF) / 255.0,
+        b: Double(v & 0xFF) / 255.0
+    )
+}
+
+/// Encode an sRGB triplet as `#RRGGBB`, uppercased. Components are
+/// rounded with banker's rounding (Swift's default) and clamped to
+/// `0...255` so out-of-range inputs don't overflow the byte.
+public func encodeHexColor(_ rgb: RGB) -> String {
+    func channel(_ x: Double) -> UInt32 {
+        let scaled = (x * 255.0).rounded()
+        return UInt32(max(0, min(255, scaled)))
+    }
+    return String(
+        format: "#%02X%02X%02X",
+        channel(rgb.r),
+        channel(rgb.g),
+        channel(rgb.b)
+    )
+}

--- a/Tests/DynamicIslandCoreTests/HexColorTests.swift
+++ b/Tests/DynamicIslandCoreTests/HexColorTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import DynamicIslandCore
+
+final class HexColorTests: XCTestCase {
+
+    // MARK: - parseHexColor
+
+    func testParse_acceptsHashPrefix() {
+        let rgb = parseHexColor("#FFFFFF")
+        XCTAssertEqual(rgb, RGB(r: 1, g: 1, b: 1))
+    }
+
+    func testParse_acceptsNoHashPrefix() {
+        let rgb = parseHexColor("FFFFFF")
+        XCTAssertEqual(rgb, RGB(r: 1, g: 1, b: 1))
+    }
+
+    func testParse_lowercase() {
+        let rgb = parseHexColor("#d9a673")
+        XCTAssertNotNil(rgb)
+        XCTAssertEqual(rgb!.r, 217.0 / 255.0, accuracy: 1e-9)
+        XCTAssertEqual(rgb!.g, 166.0 / 255.0, accuracy: 1e-9)
+        XCTAssertEqual(rgb!.b, 115.0 / 255.0, accuracy: 1e-9)
+    }
+
+    func testParse_trimsWhitespace() {
+        XCTAssertEqual(parseHexColor("  #000000  "), RGB(r: 0, g: 0, b: 0))
+    }
+
+    func testParse_rejectsShort() {
+        XCTAssertNil(parseHexColor("#FFF"))
+    }
+
+    func testParse_rejectsLong() {
+        XCTAssertNil(parseHexColor("#FFFFFF00"))
+    }
+
+    func testParse_rejectsNonHex() {
+        XCTAssertNil(parseHexColor("#GGGGGG"))
+    }
+
+    func testParse_rejectsEmpty() {
+        XCTAssertNil(parseHexColor(""))
+        XCTAssertNil(parseHexColor("#"))
+    }
+
+    // MARK: - encodeHexColor
+
+    func testEncode_pureChannels() {
+        XCTAssertEqual(encodeHexColor(RGB(r: 1, g: 0, b: 0)), "#FF0000")
+        XCTAssertEqual(encodeHexColor(RGB(r: 0, g: 1, b: 0)), "#00FF00")
+        XCTAssertEqual(encodeHexColor(RGB(r: 0, g: 0, b: 1)), "#0000FF")
+    }
+
+    func testEncode_clampsOverRange() {
+        XCTAssertEqual(encodeHexColor(RGB(r: 1.5, g: -0.2, b: 0.5)), "#FF0080")
+    }
+
+    // MARK: - Round-trip
+
+    func testRoundTrip_defaults() {
+        for hex in ["#D9A673", "#A680F2", "#4CCC99"] {
+            let rgb = parseHexColor(hex)
+            XCTAssertNotNil(rgb, "should parse \(hex)")
+            XCTAssertEqual(encodeHexColor(rgb!), hex)
+        }
+    }
+}


### PR DESCRIPTION
Closes #45. Phase 2 of the Settings panel — adds two more tabs to
the General one shipped in #42.

## Summary

- **Appearance tab** — `ColorPicker × 3` for the source palette
  (Claude / Copilot / Codex). Hex-string UserDefaults; defaults
  registered to today's hardcoded palette so untouched users see
  no change. Reset button restores defaults.
- **Hooks tab** — auto-sync toggles + Reinstall buttons for
  Claude and Codex; Copilot section explains the per-repo CLI.
  Supersedes the menu-bar "Reinstall …" items, which are removed.
- Menu bar simplifies to header / Settings… / Quit.

## Architecture

### Source colours
- `Sources/DynamicIslandCore/HexColor.swift` (new) — pure
  parse / encode helpers (`parseHexColor` / `encodeHexColor` /
  `RGB`). Tested in `HexColorTests` (11 cases).
- `IslandEvent.sourceColor(_:)` reads
  `dynamicIslandUserDefaults` for the hex (per-source key), parses,
  falls back to the registered default. Reactive — next event
  picks up the new colour.
- `SettingsView` adapter `hexBinding(_:)` round-trips through
  `NSColor.usingColorSpace(.sRGB)` so non-sRGB picks from the
  system colour panel flatten cleanly before storage.

### Per-provider auto-sync
- `applicationDidFinishLaunching` gates `syncIfOutdated(target:)`
  on `autoSyncClaudeKey` / `autoSyncCodexKey`. Defaults: Claude
  on, Codex on, Copilot off.
- Hooks tab Reinstall path mirrors the legacy `@objc reinstallHooks`
  / `reinstallCodexHooks` semantics, including bumping
  `hookInstallChoice` to `installed` on a successful Claude
  reinstall.

### Tabs
- `SettingsView` restructured to `TabView`. General tab content
  unchanged; the in-tab Reinstall button moved to the Hooks tab.
- Helper text under the inline-reply toggle now points to the
  Hooks tab for the actual reinstall step.

## Test plan

- [x] `swift build` clean, `swift test`: 173 → **184 tests**,
  0 failures (+11 in `HexColorTests`).
- [ ] **Manual** — Appearance: change Claude colour → next
  Claude-sourced event tints with new colour; Reset restores.
- [ ] **Manual** — Hooks: toggle off "Auto-sync at launch" for
  Claude → relaunch → no `syncIfOutdated` call (verifiable from
  logs or a deliberate binary swap).
- [ ] **Manual** — menu bar shows just header, Settings…,
  separator, Quit.

## Out of scope

- Project-hash palette customisation (`IslandEvent.projectColor`'s
  8-colour fallback for events without a `source`). That's a
  separate visual mechanism from the source palette.
- Copilot per-repo Reinstall button (no global notion of which
  repos are installed).
- Removing the inline-reply env-var gate (cross-process sync
  plumbing, not removable scaffolding — see `feedback_dogfood_gate_vs_sync_mechanism`
  memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)