### PR TITLE
feat(settings): Diagnostics & Tools tab

### DIFF
--- a/Sources/DynamicIsland/HookInstaller.swift
+++ b/Sources/DynamicIsland/HookInstaller.swift
@@ -309,6 +309,20 @@ enum HookInstaller {
             || FileManager.default.fileExists(atPath: target.deployedHookURL.path)
     }
 
+    /// One-line status for the Diagnostics tab. Composes
+    /// `hasExistingInstall` + `currentlyInSync` so the UI doesn't
+    /// have to know which combination corresponds to which label.
+    enum InstallStatus: Equatable {
+        case notInstalled
+        case installedAndCurrent
+        case installedButOutdated
+    }
+
+    static func installStatus(target: Target) -> InstallStatus {
+        guard hasExistingInstall(target: target) else { return .notInstalled }
+        return currentlyInSync(target: target) ? .installedAndCurrent : .installedButOutdated
+    }
+
     // MARK: - Source resolution
 
     /// Locates the bundled `island-hook` binary that we deploy into the user's

--- a/Sources/DynamicIsland/IslandState.swift
+++ b/Sources/DynamicIsland/IslandState.swift
@@ -206,17 +206,13 @@ struct SessionChannel: Identifiable {
 /// surfaced by Settings → Diagnostics. Captured at the top of
 /// `pushEvent` so the buffer includes events that were dropped by
 /// the dispatch logic, not just ones the user saw.
-struct RecentEvent: Identifiable, Equatable {
+struct RecentEvent: Identifiable {
     let id = UUID()
     let timestamp: Date
     let title: String
     let style: EventStyle
     let source: String?
     let disposition: EventDisposition
-
-    static func == (lhs: RecentEvent, rhs: RecentEvent) -> Bool {
-        lhs.id == rhs.id
-    }
 }
 
 enum IslandMode: Equatable {

--- a/Sources/DynamicIsland/IslandState.swift
+++ b/Sources/DynamicIsland/IslandState.swift
@@ -202,6 +202,23 @@ struct SessionChannel: Identifiable {
 
 // MARK: - Display Mode
 
+/// One row in `IslandStateManager.recentEvents` — the audit trail
+/// surfaced by Settings → Diagnostics. Captured at the top of
+/// `pushEvent` so the buffer includes events that were dropped by
+/// the dispatch logic, not just ones the user saw.
+struct RecentEvent: Identifiable, Equatable {
+    let id = UUID()
+    let timestamp: Date
+    let title: String
+    let style: EventStyle
+    let source: String?
+    let disposition: EventDisposition
+
+    static func == (lhs: RecentEvent, rhs: RecentEvent) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
 enum IslandMode: Equatable {
     case compact
     case expanded
@@ -265,6 +282,13 @@ class IslandStateManager: ObservableObject {
     @Published private(set) var currentEventExpired: Bool = false
     private var expirationTimer: Timer?
 
+    /// Ring buffer of the last 20 events `pushEvent` was asked to handle,
+    /// regardless of disposition. Drives the Diagnostics tab so the user
+    /// can answer "why didn't this event show up?" by scrolling recent
+    /// attempts and seeing whether they were dropped, queued, or merged.
+    @Published private(set) var recentEvents: [RecentEvent] = []
+    private let recentEventsLimit = 20
+
     /// Reference to server for sending permission responses
     weak var server: LocalServer?
 
@@ -295,6 +319,7 @@ class IslandStateManager: ObservableObject {
                 currentExpired: self.currentEventExpired,
                 incoming: event.dispositionSnapshot
             )
+            self.recordRecentEvent(event, disposition: disposition)
             switch disposition {
             case .mergeProgress:
                 self.mergeProgress(into: event)
@@ -305,6 +330,24 @@ class IslandStateManager: ObservableObject {
             case .showImmediately:
                 self.showEvent(event)
             }
+        }
+    }
+
+    /// Append to the bounded `recentEvents` ring buffer that powers
+    /// the Diagnostics tab. Called for every `pushEvent` attempt
+    /// (including dropped ones) so the user can audit dispatch
+    /// outcomes.
+    private func recordRecentEvent(_ event: IslandEvent, disposition: EventDisposition) {
+        let entry = RecentEvent(
+            timestamp: Date(),
+            title: event.title,
+            style: event.style,
+            source: event.source,
+            disposition: disposition
+        )
+        recentEvents.append(entry)
+        if recentEvents.count > recentEventsLimit {
+            recentEvents.removeFirst(recentEvents.count - recentEventsLimit)
         }
     }
 

--- a/Sources/DynamicIsland/SelfTest.swift
+++ b/Sources/DynamicIsland/SelfTest.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// Self-test actions surfaced from Settings → Diagnostics & Tools.
+///
+/// Each action fires through the same code path a real hook would,
+/// so a green checkmark verifies the chain end-to-end (URLSession →
+/// LocalServer.handleConnection → JSON parse → IslandStateManager →
+/// SwiftUI render). Any failure points at the layer that broke
+/// rather than relying on a real Claude session to surface it.
+enum SelfTest {
+    enum Outcome: Equatable {
+        case success(String)
+        case failure(String)
+    }
+
+    /// `POST /event` with a plain `info` event. Auto-dismisses after
+    /// 3 s. Verifies the basic event path.
+    static func sendTestEvent() async -> Outcome {
+        let body: [String: Any] = [
+            "title": "Self-test",
+            "subtitle": "It works.",
+            "style": "info",
+            "duration": 3,
+            "source": "claude",
+            "project": "self-test",
+        ]
+        return await postEvent(body, action: "test event")
+    }
+
+    /// `POST /event` with an `action` style event so the user can
+    /// see Allow / Deny buttons render. They click one to dismiss;
+    /// either click verifies the decision pipeline.
+    static func sendTestPermissionFlow() async -> Outcome {
+        let body: [String: Any] = [
+            "title": "Permission",
+            "subtitle": "Bash · echo hello",
+            "style": "action",
+            "persistent": true,
+            "detail": "echo \"hello from self-test\"",
+            "source": "claude",
+            "project": "self-test",
+        ]
+        return await postEvent(body, action: "permission test")
+    }
+
+    /// Pipe a synthetic `PreToolUse` payload into the deployed Codex
+    /// hook binary if one is installed. Verifies the Codex
+    /// installation works end-to-end (binary present, JSON parse,
+    /// HTTP back to the local server).
+    static func testCodexHook(deployedHookURL: URL) async -> Outcome {
+        guard FileManager.default.fileExists(atPath: deployedHookURL.path) else {
+            return .failure("Codex hook not installed at \(deployedHookURL.path)")
+        }
+        let payload: [String: Any] = [
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": ["command": "echo codex self-test"],
+            "cwd": NSHomeDirectory(),
+            "session_id": "self-test-\(UUID().uuidString)",
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: payload) else {
+            return .failure("could not serialise test payload")
+        }
+
+        return await Task.detached { () -> Outcome in
+            let process = Process()
+            process.executableURL = deployedHookURL
+            process.environment = [
+                "ISLAND_SOURCE": "codex",
+                "PATH": ProcessInfo.processInfo.environment["PATH"] ?? "/usr/bin:/bin",
+            ]
+            let stdinPipe = Pipe()
+            let stderrPipe = Pipe()
+            process.standardInput = stdinPipe
+            process.standardOutput = Pipe()
+            process.standardError = stderrPipe
+            do {
+                try process.run()
+                stdinPipe.fileHandleForWriting.write(data)
+                try? stdinPipe.fileHandleForWriting.close()
+                process.waitUntilExit()
+                if process.terminationStatus == 0 {
+                    return .success("Codex hook ran cleanly. Look for the test event on the island.")
+                }
+                let errData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+                let errText = String(data: errData, encoding: .utf8) ?? ""
+                return .failure("hook exited \(process.terminationStatus): \(errText.isEmpty ? "(no stderr)" : errText)")
+            } catch {
+                return .failure(error.localizedDescription)
+            }
+        }.value
+    }
+
+    // MARK: - HTTP helper
+
+    private static func postEvent(_ body: [String: Any], action: String) async -> Outcome {
+        guard let url = URL(string: "http://127.0.0.1:9423/event") else {
+            return .failure("could not build test URL")
+        }
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        do {
+            req.httpBody = try JSONSerialization.data(withJSONObject: body)
+        } catch {
+            return .failure("could not serialise \(action): \(error.localizedDescription)")
+        }
+        do {
+            let (data, response) = try await URLSession.shared.data(for: req)
+            guard let http = response as? HTTPURLResponse else {
+                return .failure("\(action): no HTTP response")
+            }
+            guard (200..<300).contains(http.statusCode) else {
+                let text = String(data: data, encoding: .utf8) ?? ""
+                return .failure("\(action): HTTP \(http.statusCode) \(text)")
+            }
+            return .success("Sent \(action). Look for it on the island.")
+        } catch {
+            return .failure("\(action): \(error.localizedDescription)")
+        }
+    }
+}

--- a/Sources/DynamicIsland/SettingsView.swift
+++ b/Sources/DynamicIsland/SettingsView.swift
@@ -24,6 +24,8 @@ struct SettingsView: View {
                 .tabItem { Label("Appearance", systemImage: "paintpalette") }
             HooksTab()
                 .tabItem { Label("Hooks", systemImage: "link") }
+            DiagnosticsTab(stateManager: stateManager)
+                .tabItem { Label("Diagnostics", systemImage: "stethoscope") }
         }
         .padding()
         .frame(minWidth: 480, minHeight: 440)

--- a/Sources/DynamicIsland/Views/DiagnosticsTab.swift
+++ b/Sources/DynamicIsland/Views/DiagnosticsTab.swift
@@ -1,0 +1,229 @@
+import DynamicIslandCore
+import SwiftUI
+
+// MARK: - Diagnostics & Tools tab
+
+/// Fourth tab in the Settings panel (#49). Two sections:
+///
+/// - **Diagnostics** — read-only "is the install healthy?" surface:
+///   server reachability, per-target hook install status, and a
+///   ring buffer of the last 20 events `pushEvent` was asked to
+///   handle (including dropped ones, useful for diagnosis).
+/// - **Tools** — three self-test buttons that exercise the full
+///   chain so the user can sanity-check the wiring without
+///   spinning up a real Claude session.
+struct DiagnosticsTab: View {
+    @ObservedObject var stateManager: IslandStateManager
+
+    @State private var sendStatus = SelfTest.Outcome?.none
+    @State private var permissionStatus = SelfTest.Outcome?.none
+    @State private var codexStatus = SelfTest.Outcome?.none
+
+    var body: some View {
+        Form {
+            Section {
+                serverStatusRow
+            } header: {
+                Text("Server").font(.headline)
+            }
+
+            Section {
+                hookRow(label: "Claude Code", target: .claudeCode)
+                hookRow(label: "Codex", target: .codex)
+                Text("Copilot hooks are per-repository — not visible from the global app launch path.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            } header: {
+                Text("Hooks").font(.headline)
+            }
+
+            Section {
+                toolButton(
+                    title: "Send Test Event",
+                    status: sendStatus
+                ) {
+                    Task { sendStatus = await SelfTest.sendTestEvent() }
+                }
+                toolButton(
+                    title: "Test Permission Flow",
+                    status: permissionStatus
+                ) {
+                    Task { permissionStatus = await SelfTest.sendTestPermissionFlow() }
+                }
+                toolButton(
+                    title: "Test Codex Hook",
+                    status: codexStatus,
+                    disabled: !codexInstalled
+                ) {
+                    Task {
+                        codexStatus = await SelfTest.testCodexHook(
+                            deployedHookURL: HookInstaller.Target.codex.deployedHookURL
+                        )
+                    }
+                }
+            } header: {
+                Text("Tools").font(.headline)
+            } footer: {
+                Text("Each button fires a payload through the same code path a real hook would. Look for the result on the island as well as the inline status here.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Section {
+                if stateManager.recentEvents.isEmpty {
+                    Text("No events yet — fire a Tools button or wait for hook traffic.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                } else {
+                    ForEach(stateManager.recentEvents.reversed()) { entry in
+                        recentRow(entry)
+                    }
+                }
+            } header: {
+                Text("Recent events (last \(stateManager.recentEvents.count))")
+                    .font(.headline)
+            } footer: {
+                Text("Last 20 attempts captured at the top of `pushEvent`. Dropped events show up here too — useful for diagnosing 'why didn't this surface?' questions.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    // MARK: - Subviews
+
+    @ViewBuilder
+    private var serverStatusRow: some View {
+        HStack {
+            Text("HTTP listener")
+            Spacer()
+            Text("127.0.0.1:9423")
+                .font(.system(.body, design: .monospaced))
+                .foregroundColor(.secondary)
+        }
+        Text("Hooks POST events to this address. The Tools section below sanity-checks the path.")
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    @ViewBuilder
+    private func hookRow(label: String, target: HookInstaller.Target) -> some View {
+        let status = HookInstaller.installStatus(target: target)
+        HStack {
+            Text(label)
+            Spacer()
+            statusBadge(status)
+        }
+        Text(target.deployedHookURL.path)
+            .font(.system(.caption, design: .monospaced))
+            .foregroundColor(.secondary)
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .textSelection(.enabled)
+    }
+
+    @ViewBuilder
+    private func statusBadge(_ status: HookInstaller.InstallStatus) -> some View {
+        switch status {
+        case .notInstalled:
+            Label("Not installed", systemImage: "circle.slash")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        case .installedAndCurrent:
+            Label("Installed", systemImage: "checkmark.circle.fill")
+                .font(.caption)
+                .foregroundColor(.green)
+        case .installedButOutdated:
+            Label("Out of sync", systemImage: "exclamationmark.triangle.fill")
+                .font(.caption)
+                .foregroundColor(.orange)
+        }
+    }
+
+    @ViewBuilder
+    private func toolButton(
+        title: String,
+        status: SelfTest.Outcome?,
+        disabled: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        HStack {
+            Button(title, action: action)
+                .disabled(disabled)
+            outcomeLabel(status)
+            Spacer()
+        }
+    }
+
+    @ViewBuilder
+    private func outcomeLabel(_ outcome: SelfTest.Outcome?) -> some View {
+        switch outcome {
+        case .none:
+            EmptyView()
+        case .success(let msg):
+            Label(msg, systemImage: "checkmark.circle.fill")
+                .foregroundColor(.green)
+                .font(.caption)
+                .lineLimit(2)
+        case .failure(let msg):
+            Label(msg, systemImage: "exclamationmark.triangle.fill")
+                .foregroundColor(.red)
+                .font(.caption)
+                .lineLimit(2)
+        }
+    }
+
+    @ViewBuilder
+    private func recentRow(_ entry: RecentEvent) -> some View {
+        HStack(spacing: 8) {
+            Text(timeFormatter.string(from: entry.timestamp))
+                .font(.system(.caption, design: .monospaced))
+                .foregroundColor(.secondary)
+            Text(entry.title)
+                .font(.caption)
+                .lineLimit(1)
+            Text(entry.style.rawValue)
+                .font(.caption2)
+                .foregroundColor(entry.style.color)
+            Spacer()
+            dispositionBadge(entry.disposition)
+        }
+    }
+
+    @ViewBuilder
+    private func dispositionBadge(_ disposition: EventDisposition) -> some View {
+        let (text, color): (String, Color) = {
+            switch disposition {
+            case .showImmediately: return ("shown", .green)
+            case .queueAsAction: return ("queued", .blue)
+            case .mergeProgress: return ("merged", .gray)
+            case .dropTransient: return ("dropped", .red)
+            }
+        }()
+        Text(text)
+            .font(.caption2)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 1)
+            .background(
+                Capsule().fill(color.opacity(0.18))
+            )
+            .foregroundColor(color)
+    }
+
+    private var codexInstalled: Bool {
+        FileManager.default.fileExists(
+            atPath: HookInstaller.Target.codex.deployedHookURL.path
+        )
+    }
+
+    private var timeFormatter: DateFormatter {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm:ss"
+        return f
+    }
+}

--- a/Sources/DynamicIsland/Views/DiagnosticsTab.swift
+++ b/Sources/DynamicIsland/Views/DiagnosticsTab.swift
@@ -181,7 +181,7 @@ struct DiagnosticsTab: View {
     @ViewBuilder
     private func recentRow(_ entry: RecentEvent) -> some View {
         HStack(spacing: 8) {
-            Text(timeFormatter.string(from: entry.timestamp))
+            Text(Self.timeFormatter.string(from: entry.timestamp))
                 .font(.system(.caption, design: .monospaced))
                 .foregroundColor(.secondary)
             Text(entry.title)
@@ -221,9 +221,11 @@ struct DiagnosticsTab: View {
         )
     }
 
-    private var timeFormatter: DateFormatter {
+    /// Static so we don't allocate a new formatter on every body /
+    /// row re-render — `DateFormatter.init` is non-trivial.
+    private static let timeFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "HH:mm:ss"
         return f
-    }
+    }()
 }


### PR DESCRIPTION
Closes #49. README backlog items 4 + 5 combined into one Settings tab.

## What this PR does

Adds a fourth tab to the Settings panel (next to General /
Appearance / Hooks shipped in v1.7.0 / v1.8.0).

### Diagnostics section

- **Server** — HTTP listener address.
- **Hooks** — per-target install status badge (Not installed /
  Installed / Out of sync) + deployed-binary path. Backed by a
  new `HookInstaller.installStatus(target:)` accessor.
- **Recent events** — ring buffer of the last 20 events
  `pushEvent` saw, with disposition badge (shown / queued /
  merged / dropped). Captured at the *top* of `pushEvent` so
  dropped events show up too — answers "why didn't this surface?"
  at a glance.

### Tools section (self-test)

Three async buttons firing the corresponding payload through
the same code path a real hook would:

- **Send Test Event** — `URLSession` POST a plain `info` event.
- **Test Permission Flow** — POST an `action`-style event with
  Allow / Deny buttons.
- **Test Codex Hook** — subprocess-pipe a synthetic `PreToolUse`
  payload into `~/.codex/hooks/dynamic-island-hook`. Disabled
  when not installed.

Each button shows inline status (success / error) below itself,
same pattern as the Reinstall buttons in the Hooks tab.

## Plumbing

- `IslandStateManager` — new `RecentEvent` struct +
  `recentEvents: [RecentEvent]` `@Published` ring buffer (cap 20)
  + `recordRecentEvent` helper.
- `HookInstaller` — new `InstallStatus` enum +
  `installStatus(target:)` accessor that composes the existing
  `hasExistingInstall` + `currentlyInSync` checks.
- `Sources/DynamicIsland/SelfTest.swift` (new) — three async
  helpers, return `Outcome.success(String)` / `.failure(String)`
  for inline status binding.
- `Sources/DynamicIsland/Views/DiagnosticsTab.swift` (new) — the
  SwiftUI tab.
- `SettingsView.swift` — fourth tab wired with `stethoscope` icon.

## Test plan

- [x] `swift build` clean.
- [x] `swift test`: **217 tests**, 0 failures (unchanged from
  v1.8.0 — new code is in the executable target, no
  `@testable import` seam, matches repo precedent).
- [x] Settings → Diagnostics opens with all four sections.
- [x] Send Test Event surfaces on the island.
- [x] Recent events ring buffer captures attempts and shows the
  correct disposition badge.
- [ ] **Manual** — Test Codex Hook button against an actual
  Codex install (not exercised in dev environment).

## Out of scope

- Live event stream (WebSocket / SSE) for an always-open
  diagnostics window — recent events buffer + manual reopen is
  enough for v1.
- Test for the Claude hook (assumed live in any dogfood
  session); Codex is the one users may install once and forget.
- Configurable buffer size / "clear buffer" action — defer if
  asked.

## Next on the v1.7.0 backlog

After this lands, only `#1 — Harden /event /response API
(per-launch token + CORS)` remains from the README roadmap.