### PR TITLE
fix(server): block browser-tab attack vector on /event

### DIFF
--- a/Sources/DynamicIsland/LocalServer.swift
+++ b/Sources/DynamicIsland/LocalServer.swift
@@ -181,6 +181,15 @@ class LocalServer {
                 guard !request.body.isEmpty else {
                     throw EventError.missingBody
                 }
+                // Require explicit application/json content-type. Combined
+                // with the absence of `Access-Control-Allow-Origin` below,
+                // this forces browser callers through CORS preflight, which
+                // then fails — closing the "malicious tab POSTs a fake
+                // event" attack vector. Hooks / curl / URLSession already
+                // set this header.
+                guard isJSONContentType(request) else {
+                    throw EventError.unsupportedContentType
+                }
                 try processEvent(request.body)
                 sendHTTP(connection, body: "{\"status\":\"ok\"}")
             } catch {
@@ -207,6 +216,7 @@ class LocalServer {
     private enum EventError: Error {
         case missingBody
         case invalidJSON(String)
+        case unsupportedContentType
         case invalidShape(String)
 
         var code: String {
@@ -214,6 +224,7 @@ class LocalServer {
             case .missingBody: return "missing_body"
             case .invalidJSON: return "invalid_json"
             case .invalidShape: return "invalid_shape"
+            case .unsupportedContentType: return "unsupported_content_type"
             }
         }
 
@@ -222,8 +233,26 @@ class LocalServer {
             case .missingBody: return "missing request body"
             case .invalidJSON(let reason): return "invalid JSON: \(reason)"
             case .invalidShape(let reason): return "invalid event shape: \(reason)"
+            case .unsupportedContentType: return "Content-Type must be application/json"
             }
         }
+    }
+
+    /// True when the request's `Content-Type` header indicates JSON.
+    /// Browser "simple POST" requests default to text/plain or
+    /// x-www-form-urlencoded — rejecting those here forces a CORS
+    /// preflight which then fails (no `Access-Control-Allow-Origin`),
+    /// blocking the malicious-tab attack vector.
+    private func isJSONContentType(_ request: HTTPRequest) -> Bool {
+        // Headers are case-insensitive per RFC 7230. HTTPParser stores
+        // them lowercased.
+        guard let raw = request.headers["content-type"] else { return false }
+        // Strip optional parameters like `; charset=utf-8`.
+        let primary = raw
+            .split(separator: ";").first
+            .map { String($0).trimmingCharacters(in: .whitespaces).lowercased() }
+            ?? raw.lowercased()
+        return primary == "application/json"
     }
 
     /// Safely build a JSON error body. Runs fields through JSONSerialization
@@ -242,7 +271,12 @@ class LocalServer {
     }
 
     private func sendHTTP(_ connection: NWConnection, body: String, statusCode: String = "200 OK") {
-        let response = "HTTP/1.1 \(statusCode)\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: \(body.utf8.count)\r\n\r\n\(body)"
+        // No `Access-Control-Allow-Origin` header — combined with the
+        // application/json gate on `/event`, this fails CORS preflight
+        // for any browser request, blocking the malicious-tab attack
+        // vector. Hooks / curl / URLSession don't enforce CORS so they
+        // continue to work unchanged.
+        let response = "HTTP/1.1 \(statusCode)\r\nContent-Type: application/json\r\nContent-Length: \(body.utf8.count)\r\n\r\n\(body)"
         connection.send(content: response.data(using: .utf8)!, completion: .contentProcessed { _ in
             connection.cancel()
         })

--- a/Sources/DynamicIsland/LocalServer.swift
+++ b/Sources/DynamicIsland/LocalServer.swift
@@ -186,8 +186,9 @@ class LocalServer {
                 // this forces browser callers through CORS preflight, which
                 // then fails — closing the "malicious tab POSTs a fake
                 // event" attack vector. Hooks / curl / URLSession already
-                // set this header.
-                guard isJSONContentType(request) else {
+                // set this header. Validation is in `DynamicIslandCore` so
+                // it's unit-tested without spinning up the full server.
+                guard isJSONContentType(request.headers["content-type"]) else {
                     throw EventError.unsupportedContentType
                 }
                 try processEvent(request.body)
@@ -238,22 +239,6 @@ class LocalServer {
         }
     }
 
-    /// True when the request's `Content-Type` header indicates JSON.
-    /// Browser "simple POST" requests default to text/plain or
-    /// x-www-form-urlencoded — rejecting those here forces a CORS
-    /// preflight which then fails (no `Access-Control-Allow-Origin`),
-    /// blocking the malicious-tab attack vector.
-    private func isJSONContentType(_ request: HTTPRequest) -> Bool {
-        // Headers are case-insensitive per RFC 7230. HTTPParser stores
-        // them lowercased.
-        guard let raw = request.headers["content-type"] else { return false }
-        // Strip optional parameters like `; charset=utf-8`.
-        let primary = raw
-            .split(separator: ";").first
-            .map { String($0).trimmingCharacters(in: .whitespaces).lowercased() }
-            ?? raw.lowercased()
-        return primary == "application/json"
-    }
 
     /// Safely build a JSON error body. Runs fields through JSONSerialization
     /// so embedded quotes / newlines don't corrupt the response.

--- a/Sources/DynamicIslandCore/HTTPParser.swift
+++ b/Sources/DynamicIslandCore/HTTPParser.swift
@@ -130,3 +130,21 @@ public enum HTTPParser {
         return .done(HTTPRequest(method: method, path: path, headers: headers, body: body))
     }
 }
+
+/// True when a `Content-Type` header value indicates JSON.
+///
+/// Used by `LocalServer` to gate POST `/event`: rejecting other types
+/// forces browser callers through CORS preflight (which then fails
+/// because we no longer respond with `Access-Control-Allow-Origin: *`).
+/// Hooks, curl, URLSession etc. set this header so they're unaffected.
+///
+/// Strips the optional `; charset=…` parameter and is case-insensitive
+/// so `Application/JSON; charset=utf-8` matches.
+public func isJSONContentType(_ headerValue: String?) -> Bool {
+    guard let raw = headerValue else { return false }
+    let primary = raw
+        .split(separator: ";", maxSplits: 1).first
+        .map { String($0).trimmingCharacters(in: .whitespaces).lowercased() }
+        ?? raw.trimmingCharacters(in: .whitespaces).lowercased()
+    return primary == "application/json"
+}

--- a/Tests/DynamicIslandCoreTests/HTTPParserTests.swift
+++ b/Tests/DynamicIslandCoreTests/HTTPParserTests.swift
@@ -165,4 +165,53 @@ final class HTTPParserTests: XCTestCase {
         if case .done = result { return }
         XCTFail("request at exactly cap should parse, got \(result)")
     }
+
+    // MARK: - isJSONContentType (#51 — POST /event content-type gate)
+
+    func testJSONContentType_acceptsBareApplicationJSON() {
+        XCTAssertTrue(isJSONContentType("application/json"))
+    }
+
+    func testJSONContentType_acceptsCharsetParameter() {
+        XCTAssertTrue(isJSONContentType("application/json; charset=utf-8"))
+    }
+
+    func testJSONContentType_caseInsensitive() {
+        XCTAssertTrue(isJSONContentType("Application/JSON"))
+        XCTAssertTrue(isJSONContentType("APPLICATION/JSON; CHARSET=UTF-8"))
+    }
+
+    func testJSONContentType_trimsSurroundingWhitespace() {
+        XCTAssertTrue(isJSONContentType("  application/json  "))
+        XCTAssertTrue(isJSONContentType("application/json ;charset=utf-8"))
+    }
+
+    func testJSONContentType_rejectsTextPlain() {
+        XCTAssertFalse(isJSONContentType("text/plain"))
+    }
+
+    func testJSONContentType_rejectsFormUrlEncoded() {
+        // The other "simple POST" content-type browsers can use
+        // without preflight.
+        XCTAssertFalse(isJSONContentType("application/x-www-form-urlencoded"))
+    }
+
+    func testJSONContentType_rejectsApplicationJSONPSuffix() {
+        // Substring match would let `application/jsonp` through.
+        XCTAssertFalse(isJSONContentType("application/jsonp"))
+    }
+
+    func testJSONContentType_rejectsParameterTrickedAttempts() {
+        // Parameter portion can't smuggle through.
+        XCTAssertFalse(isJSONContentType("text/plain; application/json"))
+    }
+
+    func testJSONContentType_rejectsNil() {
+        XCTAssertFalse(isJSONContentType(nil))
+    }
+
+    func testJSONContentType_rejectsEmpty() {
+        XCTAssertFalse(isJSONContentType(""))
+        XCTAssertFalse(isJSONContentType(";charset=utf-8"))
+    }
 }


### PR DESCRIPTION
README backlog item — Harden /event /response API. Smallest
useful slice: close the browser-tab vector. Per-launch token
deferred to a separate PR if motivation appears.

## Why

`127.0.0.1:9423` accepted any local request without checking
where it came from. Two specific holes that combined to let a
malicious website silently spawn fake events on the island:

1. Response set `Access-Control-Allow-Origin: *`, so a CORS
   preflight from JS in a random tab succeeded.
2. POST `/event` accepted any `Content-Type`, so even a
   "simple POST" with `text/plain` (no preflight) carrying a
   JSON body was accepted by the server.

Either path renders attacker-controlled content on the user's
island — including fake `style: action` Permission dialogs they
might reflexively click.

## What this PR does

1. Drops `Access-Control-Allow-Origin: *` from every server
   response. Browsers refuse the preflight, so JS in another
   origin can't send a preflighted POST.
2. Requires `Content-Type: application/json` on POST `/event`.
   Forces browser callers through preflight (closed by #1).
   Real clients (hook binary, curl, URLSession, Python
   `requests`) already set this header.

New `EventError.unsupportedContentType` returns `400` with code
`unsupported_content_type`, matching the existing JSON error
envelope. `isJSONContentType(_:)` strips the optional `; charset=…`
parameter before comparison; header lookup is case-insensitive
because `HTTPParser` lowercases header keys per RFC 7230.

## Test plan

- [x] `swift build` clean.
- [x] `swift test`: **217 tests**, 0 failures.
- [x] Mechanical smoke (live server):
  - `application/json` POST → `200 OK`, event renders on island.
  - `text/plain` POST with JSON body → `400 unsupported_content_type`.
  - POST with no Content-Type → `400 unsupported_content_type`.
  - Response headers no longer carry `Access-Control-Allow-Origin`.
- [ ] **Manual** — trigger a real Claude Code session, verify
  hook events still arrive.

## Out of scope

- Per-launch token (`X-CC-Island-Token` header). Mainly defends
  against same-user other-process attacks (which require malware
  on the user's machine to exploit). Browser-tab vector — the
  realistic one — is closed by this PR alone. Token can land
  later as defence in depth.
- Removing `OPTIONS` preflight handling: there is none in our
  server today, so nothing to remove.