### PR TITLE
feat(capsule): radar-ping source dot + frosted-glass background

### DIFF
--- a/Sources/DynamicIsland/LocalServer.swift
+++ b/Sources/DynamicIsland/LocalServer.swift
@@ -358,12 +358,10 @@ class LocalServer {
 
         let style = EventStyle(rawValue: styleName) ?? .claude
 
-        let icon: String
-        if let customIcon = json["icon"] as? String {
-            icon = customIcon
-        } else {
-            icon = Self.iconForType(type)
-        }
+        // Icon is optional and only renders on the capsule. Hook-driven
+        // events don't set one; explicit callers (NotificationMonitor,
+        // manual POSTs) can still pass an emoji via the `icon` field.
+        let icon = json["icon"] as? String ?? ""
 
         // Sub-decoders below live in `DynamicIslandCore` so the
         // parsing rules (3-cap / 20-char trim / strict freeform_replyable
@@ -422,20 +420,4 @@ class LocalServer {
         stateManager?.pushEvent(event)
     }
 
-    private static func iconForType(_ type: String) -> String {
-        switch type {
-        case "tool_start": return "🔧"
-        case "tool_end": return "✅"
-        case "notification": return "🔔"
-        case "stop": return "🏁"
-        case "error": return "❌"
-        case "thinking": return "🧠"
-        case "edit": return "✏️"
-        case "bash": return "💻"
-        case "search": return "🔍"
-        case "read": return "📖"
-        case "write": return "📝"
-        default: return "🏝️"
-        }
-    }
 }

--- a/Sources/DynamicIsland/Views/Capsule.swift
+++ b/Sources/DynamicIsland/Views/Capsule.swift
@@ -86,7 +86,8 @@ struct CompactPillView: View {
         .frame(height: event.subtitle.isEmpty ? 38 : 44)
         .background(
             Capsule()
-                .fill(.black)
+                .fill(.regularMaterial)
+                .environment(\.colorScheme, .dark)
                 .overlay(Capsule().strokeBorder(event.style.glowColor, lineWidth: 1))
                 .shadow(color: event.style.glowColor, radius: 8, x: 0, y: 2)
         )
@@ -198,7 +199,8 @@ struct ExpandedPillView: View {
         .frame(maxWidth: .infinity, alignment: .topLeading)
         .background(
             RoundedRectangle(cornerRadius: 22)
-                .fill(.black)
+                .fill(.regularMaterial)
+                .environment(\.colorScheme, .dark)
                 .overlay(
                     RoundedRectangle(cornerRadius: 22)
                         .strokeBorder(

--- a/Sources/DynamicIsland/Views/Capsule.swift
+++ b/Sources/DynamicIsland/Views/Capsule.swift
@@ -6,6 +6,8 @@ struct CompactPillView: View {
     let event: IslandEvent
     @ObservedObject var stateManager: IslandStateManager
     @State private var appeared = false
+    @State private var pingScale: CGFloat = 1
+    @State private var pingOpacity: Double = 0
 
     /// Promote `event.project` to the primary title slot whenever we have
     /// one — multi-session users read "which session" before "what action".
@@ -19,12 +21,25 @@ struct CompactPillView: View {
 
     private var actionChipText: String? { hasProject ? event.title : nil }
 
+    private var dotColor: Color { event.projectColor ?? event.style.color }
+
     var body: some View {
         HStack(spacing: 8) {
-            // Source dot — the capsule's analogue to the ear's outer stripe.
-            Circle()
-                .fill(event.projectColor ?? event.style.color)
-                .frame(width: 6, height: 6)
+            // Source dot with a one-shot radar ping when a new event arrives.
+            // The ring expands + fades; the dot itself stays static.
+            ZStack {
+                Circle()
+                    .stroke(dotColor, lineWidth: 1)
+                    .frame(width: 6, height: 6)
+                    .scaleEffect(pingScale)
+                    .opacity(pingOpacity)
+                Circle()
+                    .fill(dotColor)
+                    .frame(width: 6, height: 6)
+            }
+            .frame(width: 18, height: 18)
+            .onAppear { emitPing() }
+            .onChange(of: event.id) { _ in emitPing() }
 
             if !event.icon.isEmpty {
                 Text(event.icon)
@@ -78,6 +93,15 @@ struct CompactPillView: View {
         .onTapGesture { stateManager.expand() }
         .onAppear { appeared = true }
         .onDisappear { appeared = false }
+    }
+
+    private func emitPing() {
+        pingScale = 1
+        pingOpacity = 0.9
+        withAnimation(.easeOut(duration: 0.7)) {
+            pingScale = 3.2
+            pingOpacity = 0
+        }
     }
 }
 


### PR DESCRIPTION
Two small capsule-pill visual changes. Capsule-only (fallback views on
non-notch displays); the notch ears/expanded panel are unchanged.

## 1. Radar-ping on the source dot — drop the default emoji map

The pill's icon slot rendered `LocalServer.iconForType(type)` as a
default decoration — `🏝️` for unknown events, plus `🔧` / `✏️` /
`💻` / `🔍` / etc. mapped from `tool_start` / `edit` / `bash` /
`search`. In practice no caller in this repo POSTs those `type`
values: `island-hook` drives visuals via `style`, not `type`. Users
mostly saw the `🏝️` fallback eating horizontal pill space without
carrying information.

- Removed `iconForType` entirely from `LocalServer.swift`.
- `event.icon` now only set when a caller passes `icon` explicitly,
  so `NotificationMonitor`'s `🔊` / `🔒` / `☀️` and manual POSTs
  still work.
- To keep a subtle \"new event arrived\" cue, `CompactPillView` source
  dot grows a one-shot radar ring each time `event.id` changes:
  stroke matches the dot colour, scales 1× → 3.2×, opacity 0.9 → 0
  over 0.7 s \`easeOut\`. Static dot underneath is unchanged.
  \`.onAppear\` fires for the first event; \`.onChange(of: event.id)\`
  for subsequent arrivals.
- \`ExpandedPillView\` already has the pulsing border for \`.action\` /
  \`.reminder\` events and doesn't show a source dot, so it needs no
  additional animation.

## 2. Frosted-glass capsule background

Pure \`.black\` reads cleanly but feels static next to the rest of the
macOS design language. \`.regularMaterial\` (NSVisualEffectView-backed,
macOS 12+) gives the pill a frosted-glass look — desktop colour
bleeds through just enough to feel alive, but not so much that gray
subtitle text becomes unreadable on bright backdrops.

- Tried \`.thinMaterial\` first; nicer on dark desktops but the gray
  subtitle started disappearing against bright wallpapers.
  \`.regularMaterial\` keeps the effect while recovering contrast.
- \`.environment(\.colorScheme, .dark)\` on the fill locks the dark
  material variant — without it SwiftUI flips to light under certain
  system appearance contexts and the pill goes white.
- Capsule-only: \`CompactPillView\` and \`ExpandedPillView\`. The notch
  views (\`LeftEarView\`, \`RightEarView\`, \`ExpandedContentView\`) keep
  their solid \`.black\` — the notch needs the sharp silhouette to
  blend into the hardware cutout, and a translucent ear would leak
  menubar colour through the screen edge.

## Verification

- \`swift build -c release\` — clean build.
- Local release binary running, both effects render on capsule
  fallback layout (non-notch external display).
- No new tests: changes are purely visual on SwiftUI views in the
  executable target (which has no \`@testable import\` seam, matching
  repo precedent for \`IslandView\` / \`LocalServer\`). The
  \`iconForType\` removal in \`LocalServer.swift\` is a deletion of dead
  branches — no caller path covered by existing tests references it.

## Out of scope

- Notch ears keep solid \`.black\` deliberately (see §2 above).
- The \`event.icon\` field is preserved on the data model — only the
  default-emoji fallback is removed. Callers that already pass an
  explicit emoji are unaffected.