### PR TITLE
feat(click): jump to the matching terminal tab on island tap

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -24,5 +24,7 @@
     <true/>
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.utilities</string>
+    <key>NSAppleEventsUsageDescription</key>
+    <string>Dynamic Island brings your terminal tab to the front when you tap the island.</string>
 </dict>
 </plist>

--- a/Sources/DynamicIsland/App.swift
+++ b/Sources/DynamicIsland/App.swift
@@ -134,6 +134,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             autoSyncClaudeKey: true,
             autoSyncCodexKey: true,
             autoSyncCopilotKey: false,
+            // Click-to-focus-terminal-tab: on by default; users can opt
+            // back into the legacy expand-on-click via Settings.
+            clickToTerminalKey: true,
         ])
 
         panel = IslandPanel(stateManager: stateManager)

--- a/Sources/DynamicIsland/HookInstaller.swift
+++ b/Sources/DynamicIsland/HookInstaller.swift
@@ -49,6 +49,13 @@ let stopReplyTimeoutKey = "stopReplyTimeoutSeconds"
 /// move. Default `200`.
 let screenFollowerDwellKey = "screenFollowerDwellMilliseconds"
 
+/// UserDefaults Bool key gating "click on island → focus terminal tab".
+/// When on (default), a tap on a non-decision compact ear / pill runs
+/// `TerminalActivator.activate(tty:)` and dismisses the island. When
+/// off, taps fall back to the legacy expand behaviour. Read by the tap
+/// handlers in `Ears.swift` / `Capsule.swift`.
+let clickToTerminalKey = "clickToTerminalEnabled"
+
 /// UserDefaults keys for the source colour palette (#45). Stored as
 /// `#RRGGBB` hex strings so they survive plist round-trips without a
 /// custom codable adapter. Read by `IslandEvent.sourceColor(_:)` and

--- a/Sources/DynamicIsland/IslandState.swift
+++ b/Sources/DynamicIsland/IslandState.swift
@@ -54,6 +54,13 @@ struct IslandEvent: Identifiable {
     /// same purpose as `agentID`.
     let sessionID: String?
 
+    /// Controlling TTY of the Claude Code / Copilot / Codex process that
+    /// fired this hook (e.g. `/dev/ttys003`). Forwarded by the hook so
+    /// a click on the island can ask the terminal app to focus the tab
+    /// running the session. Nil when the parent had no tty (GUI launch,
+    /// self-test) — the click then falls back to expand/collapse.
+    let tty: String?
+
     /// Color signaling event source. Falls back to a deterministic
     /// project-name hash when the source isn't known, so legacy callers
     /// (e.g. plain HTTP POST without source) still get visual variety.
@@ -105,7 +112,8 @@ struct IslandEvent: Identifiable {
         suggestedRule: PermissionRuleSuggestion? = nil,
         replyMode: ReplyMode? = nil,
         agentID: String? = nil,
-        sessionID: String? = nil
+        sessionID: String? = nil,
+        tty: String? = nil
     ) {
         self.id = id
         self.icon = icon
@@ -122,6 +130,7 @@ struct IslandEvent: Identifiable {
         self.replyMode = replyMode
         self.agentID = agentID
         self.sessionID = sessionID
+        self.tty = tty
     }
 }
 
@@ -364,7 +373,8 @@ class IslandStateManager: ObservableObject {
             persistent: event.persistent,
             project: event.project,
             source: event.source,
-            suggestedRule: event.suggestedRule
+            suggestedRule: event.suggestedRule,
+            tty: event.tty ?? current.tty
         )
         self.currentEvent = merged
         if !event.persistent {
@@ -445,6 +455,32 @@ class IslandStateManager: ObservableObject {
         withAnimation(.spring(response: 0.4, dampingFraction: 0.75)) {
             mode = .expanded
         }
+    }
+
+    /// Single entry point for compact ear / capsule taps.
+    ///
+    /// Pulsing events (action / reminder) keep their existing dismiss
+    /// behaviour because their decision UI lives on the island itself.
+    /// Everything else: when the user has click-to-terminal on (default)
+    /// and the event carries a tty, ask `TerminalActivator` to focus the
+    /// matching tab and dismiss the island. Otherwise fall back to
+    /// expanding so the user can still inspect the diff / detail.
+    ///
+    /// Kept on the state manager so the three view sites share one
+    /// policy and a future test can drive it without an NSPanel.
+    func handleCompactTap() {
+        guard let event = currentEvent else { return }
+        if event.style == .action || event.style == .reminder {
+            dismiss()
+            return
+        }
+        if let tty = event.tty,
+           dynamicIslandUserDefaults.bool(forKey: clickToTerminalKey) {
+            _ = TerminalActivator.activate(tty: tty)
+            dismiss()
+            return
+        }
+        expand()
     }
 
     func collapse() {

--- a/Sources/DynamicIsland/IslandState.swift
+++ b/Sources/DynamicIsland/IslandState.swift
@@ -475,8 +475,9 @@ class IslandStateManager: ObservableObject {
             return
         }
         if let tty = event.tty,
-           dynamicIslandUserDefaults.bool(forKey: clickToTerminalKey) {
-            _ = TerminalActivator.activate(tty: tty)
+           dynamicIslandUserDefaults.bool(forKey: clickToTerminalKey),
+           TerminalActivator.hasRunningTerminal() {
+            TerminalActivator.activate(tty: tty)
             dismiss()
             return
         }

--- a/Sources/DynamicIsland/LocalServer.swift
+++ b/Sources/DynamicIsland/LocalServer.swift
@@ -388,6 +388,10 @@ class LocalServer {
         let payloadID = (json["event_id"] as? String).flatMap(UUID.init(uuidString:))
         let agentIDValue = json["agent_id"] as? String
         let sessionIDValue = json["session_id"] as? String
+        // `decodeTTY` enforces a strict `/dev/ttys<N>` / `/dev/pts/<N>`
+        // allow-list before this string ever reaches AppleScript. See
+        // EventDecoder.decodeTTY for the shell-injection rationale.
+        let ttyValue = decodeTTY(from: json["tty"])
         let event = IslandEvent(
             id: payloadID ?? UUID(),
             icon: icon,
@@ -403,7 +407,8 @@ class LocalServer {
             suggestedRule: suggestedRule,
             replyMode: replyMode,
             agentID: agentIDValue,
-            sessionID: sessionIDValue
+            sessionID: sessionIDValue,
+            tty: ttyValue
         )
 
         // Route into the session tree: main session when no agent_id, else

--- a/Sources/DynamicIsland/SettingsView.swift
+++ b/Sources/DynamicIsland/SettingsView.swift
@@ -38,6 +38,9 @@ private struct GeneralTab: View {
     @AppStorage(enableInlineReplyKey, store: dynamicIslandUserDefaults)
     private var inlineReplyEnabled = false
 
+    @AppStorage(clickToTerminalKey, store: dynamicIslandUserDefaults)
+    private var clickToTerminalEnabled = true
+
     @AppStorage(stopReplyTimeoutKey, store: dynamicIslandUserDefaults)
     private var stopReplyTimeoutSeconds: Double = StopReplyTimeoutSeconds
 
@@ -46,6 +49,16 @@ private struct GeneralTab: View {
 
     var body: some View {
         Form {
+            Section {
+                Toggle("Click island to focus terminal tab", isOn: $clickToTerminalEnabled)
+                Text("Tapping a non-decision event jumps to the Terminal.app or iTerm2 tab running the matching session. Falls back to expanding the event when the tab can't be located. Turn off to keep the legacy expand-on-tap behaviour.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            } header: {
+                Text("Click behaviour").font(.headline)
+            }
+
             Section {
                 Toggle("Inline reply for Stop events", isOn: $inlineReplyEnabled)
                 Text("Lets you reply to Claude's free-form questions directly from the island. Toggling this changes the UI immediately, but the hook side only picks it up after reinstalling Claude Code hooks (see Hooks tab).")

--- a/Sources/DynamicIsland/TerminalActivator.swift
+++ b/Sources/DynamicIsland/TerminalActivator.swift
@@ -1,0 +1,132 @@
+import AppKit
+import Foundation
+
+/// Bring the terminal tab whose controlling TTY matches `tty` to the front.
+///
+/// Used by the ear / capsule tap handler so a click on the island jumps to
+/// the actual terminal pane running Claude Code. Works against Terminal.app
+/// and iTerm2 (the two terminals with rich AppleScript tab support); for
+/// everything else we fall back to activating whatever terminal app is
+/// frontmost so the user at least gets back to *a* terminal.
+///
+/// Safety: `tty` is decoded by `decodeTTY` upstream, which only admits
+/// `/dev/ttys<digits>` or `/dev/pts/<digits>`. That keeps the AppleScript
+/// interpolation below from being a shell-injection sink even though the
+/// payload originates from an HTTP POST.
+enum TerminalActivator {
+    enum Result: Equatable {
+        case focused(app: String)   // tab successfully focused
+        case appActivated(String)   // tab not found, but we surfaced the app
+        case noMatch                // no supported terminal could focus it
+    }
+
+    static func activate(tty: String) -> Result {
+        // Order matters: try the app the tty most likely belongs to first.
+        // We probe Terminal then iTerm2 — both are no-ops when not running.
+        if isRunning(bundleID: "com.apple.Terminal"),
+           runScript(terminalAppScript(tty: tty)) {
+            return .focused(app: "Terminal")
+        }
+        if isRunning(bundleID: "com.googlecode.iterm2"),
+           runScript(iTermScript(tty: tty)) {
+            return .focused(app: "iTerm2")
+        }
+        // Fall back to surfacing whichever terminal-class app is running so
+        // the user lands somewhere familiar even if we can't pick the tab.
+        if let bundleID = firstRunningTerminalBundleID() {
+            NSWorkspace.shared.runningApplications
+                .first { $0.bundleIdentifier == bundleID }?
+                .activate(options: [])
+            return .appActivated(bundleID)
+        }
+        return .noMatch
+    }
+
+    // MARK: - AppleScript sources
+
+    /// Terminal.app exposes `tty` directly on each tab. Setting `selected`
+    /// switches to it and `frontmost` raises the window. Returns true on
+    /// match so the calling NSAppleScript run flips its result code.
+    private static func terminalAppScript(tty: String) -> String {
+        """
+        tell application "Terminal"
+            repeat with w in windows
+                repeat with t in tabs of w
+                    try
+                        if tty of t is "\(tty)" then
+                            set selected of t to true
+                            set frontmost of w to true
+                            activate
+                            return true
+                        end if
+                    end try
+                end repeat
+            end repeat
+            return false
+        end tell
+        """
+    }
+
+    /// iTerm2 nests sessions under tabs under windows, with `tty` on the
+    /// session. `select` raises the session's tab and window in one go.
+    private static func iTermScript(tty: String) -> String {
+        """
+        tell application "iTerm"
+            repeat with w in windows
+                repeat with t in tabs of w
+                    repeat with s in sessions of t
+                        try
+                            if tty of s is "\(tty)" then
+                                select s
+                                activate
+                                return true
+                            end if
+                        end try
+                    end repeat
+                end repeat
+            end repeat
+            return false
+        end tell
+        """
+    }
+
+    // MARK: - NSAppleScript runner
+
+    private static func runScript(_ source: String) -> Bool {
+        guard let script = NSAppleScript(source: source) else { return false }
+        var errorDict: NSDictionary?
+        let descriptor = script.executeAndReturnError(&errorDict)
+        if errorDict != nil { return false }
+        // The scripts above return a boolean; bridge it back. AppleScript
+        // booleans surface as `typeBoolean` (1/0) in NSAppleEventDescriptor.
+        return descriptor.booleanValue
+    }
+
+    // MARK: - App discovery
+
+    private static func isRunning(bundleID: String) -> Bool {
+        NSWorkspace.shared.runningApplications.contains {
+            $0.bundleIdentifier == bundleID
+        }
+    }
+
+    /// Bundle IDs of the most common macOS terminal apps. Order doesn't
+    /// matter — any one being frontmost is good enough for the fallback.
+    private static let knownTerminalBundleIDs: [String] = [
+        "com.apple.Terminal",
+        "com.googlecode.iterm2",
+        "com.mitchellh.ghostty",
+        "com.github.wez.wezterm",
+        "dev.warp.Warp-Stable",
+        "co.zeit.hyper",
+        "net.kovidgoyal.kitty",
+        "io.alacritty",
+    ]
+
+    private static func firstRunningTerminalBundleID() -> String? {
+        let running = Set(
+            NSWorkspace.shared.runningApplications.compactMap { $0.bundleIdentifier }
+        )
+        return knownTerminalBundleIDs.first { running.contains($0) }
+    }
+}

--- a/Sources/DynamicIsland/TerminalActivator.swift
+++ b/Sources/DynamicIsland/TerminalActivator.swift
@@ -14,32 +14,55 @@ import Foundation
 /// interpolation below from being a shell-injection sink even though the
 /// payload originates from an HTTP POST.
 enum TerminalActivator {
-    enum Result: Equatable {
-        case focused(app: String)   // tab successfully focused
-        case appActivated(String)   // tab not found, but we surfaced the app
-        case noMatch                // no supported terminal could focus it
+    /// Cheap synchronous check: is any supported terminal app currently
+    /// running? Called on the main thread before `activate(tty:)` so the
+    /// tap handler can fall back to `expand()` when there's no terminal
+    /// to switch to (instead of silently dismissing the island).
+    static func hasRunningTerminal() -> Bool {
+        firstRunningTerminalBundleID() != nil
     }
 
-    static func activate(tty: String) -> Result {
-        // Order matters: try the app the tty most likely belongs to first.
-        // We probe Terminal then iTerm2 — both are no-ops when not running.
-        if isRunning(bundleID: "com.apple.Terminal"),
-           runScript(terminalAppScript(tty: tty)) {
-            return .focused(app: "Terminal")
+    /// Fire-and-forget: focus the terminal tab whose controlling TTY
+    /// matches `tty`. Async-dispatched on the main queue so the caller's
+    /// dismiss animation gets to start before AppleScript blocks
+    /// (~100-500ms on iTerm2 with many windows).
+    ///
+    /// Must run on main: NSAppleScript from a background queue has no
+    /// CFRunLoop and silently swallows the AppleEvent dispatch + TCC
+    /// permission prompt; NSWorkspace.runningApplications is also
+    /// documented main-thread-only.
+    ///
+    /// Callers must precheck `hasRunningTerminal()` — when no terminal is
+    /// running we do nothing here, leaving the UI decision (expand vs
+    /// dismiss) to the caller.
+    static func activate(tty: String) {
+        DispatchQueue.main.async {
+            let runningIDs = Set(
+                NSWorkspace.shared.runningApplications.compactMap { $0.bundleIdentifier }
+            )
+            if runningIDs.contains("com.apple.Terminal"),
+               runScript(terminalAppScript(tty: tty)) {
+                return
+            }
+            if runningIDs.contains("com.googlecode.iterm2"),
+               runScript(iTermScript(tty: tty)) {
+                // AppleScript `activate` doesn't reliably surface
+                // fullscreen-Space iTerm windows from an LSUIElement
+                // caller — belt-and-suspenders with NSWorkspace.
+                NSWorkspace.shared.runningApplications
+                    .first { $0.bundleIdentifier == "com.googlecode.iterm2" }?
+                    .activate(options: [.activateAllWindows])
+                return
+            }
+            // No tab matched. Surface whichever terminal app is running
+            // so the user lands somewhere familiar.
+            if let fallbackID = knownTerminalBundleIDs
+                .first(where: { runningIDs.contains($0) }) {
+                NSWorkspace.shared.runningApplications
+                    .first { $0.bundleIdentifier == fallbackID }?
+                    .activate(options: [.activateAllWindows])
+            }
         }
-        if isRunning(bundleID: "com.googlecode.iterm2"),
-           runScript(iTermScript(tty: tty)) {
-            return .focused(app: "iTerm2")
-        }
-        // Fall back to surfacing whichever terminal-class app is running so
-        // the user lands somewhere familiar even if we can't pick the tab.
-        if let bundleID = firstRunningTerminalBundleID() {
-            NSWorkspace.shared.runningApplications
-                .first { $0.bundleIdentifier == bundleID }?
-                .activate(options: [])
-            return .appActivated(bundleID)
-        }
-        return .noMatch
     }
 
     // MARK: - AppleScript sources
@@ -77,6 +100,9 @@ enum TerminalActivator {
                     repeat with s in sessions of t
                         try
                             if tty of s is "\(tty)" then
+                                tell w
+                                    select t
+                                end tell
                                 select s
                                 activate
                                 return true
@@ -103,12 +129,6 @@ enum TerminalActivator {
     }
 
     // MARK: - App discovery
-
-    private static func isRunning(bundleID: String) -> Bool {
-        NSWorkspace.shared.runningApplications.contains {
-            $0.bundleIdentifier == bundleID
-        }
-    }
 
     /// Bundle IDs of the most common macOS terminal apps. Order doesn't
     /// matter — any one being frontmost is good enough for the fallback.

--- a/Sources/DynamicIsland/Views/Capsule.swift
+++ b/Sources/DynamicIsland/Views/Capsule.swift
@@ -151,7 +151,8 @@ struct ExpandedPillView: View {
                 PermissionActionButtons(
                     stateManager: stateManager,
                     suggestedRule: event.suggestedRule,
-                    eventID: event.id
+                    eventID: event.id,
+                    tty: event.tty
                 )
             }
 

--- a/Sources/DynamicIsland/Views/Capsule.swift
+++ b/Sources/DynamicIsland/Views/Capsule.swift
@@ -75,7 +75,7 @@ struct CompactPillView: View {
                 .overlay(Capsule().strokeBorder(event.style.glowColor, lineWidth: 1))
                 .shadow(color: event.style.glowColor, radius: 8, x: 0, y: 2)
         )
-        .onTapGesture { stateManager.expand() }
+        .onTapGesture { stateManager.handleCompactTap() }
         .onAppear { appeared = true }
         .onDisappear { appeared = false }
     }

--- a/Sources/DynamicIsland/Views/Ears.swift
+++ b/Sources/DynamicIsland/Views/Ears.swift
@@ -139,9 +139,7 @@ struct LeftEarView: View {
                 : .clear,
             radius: 8
         )
-        .onTapGesture {
-            if isPulsing { stateManager.dismiss() } else { stateManager.expand() }
-        }
+        .onTapGesture { stateManager.handleCompactTap() }
         .onChange(of: isVisible) { vis in
             withAnimation(.spring(response: 0.3, dampingFraction: 0.6).delay(0.05)) {
                 appeared = vis
@@ -217,9 +215,7 @@ struct RightEarView: View {
                 : .clear,
             radius: 8
         )
-        .onTapGesture {
-            if isPulsing { stateManager.dismiss() } else { stateManager.expand() }
-        }
+        .onTapGesture { stateManager.handleCompactTap() }
         .onChange(of: isVisible) { vis in
             if vis && isPulsing {
                 withAnimation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true)) {

--- a/Sources/DynamicIsland/Views/ExpandedContent.swift
+++ b/Sources/DynamicIsland/Views/ExpandedContent.swift
@@ -51,7 +51,8 @@ struct ExpandedContentView: View {
                 PermissionActionButtons(
                     stateManager: stateManager,
                     suggestedRule: event.suggestedRule,
-                    eventID: event.id
+                    eventID: event.id,
+                    tty: event.tty
                 )
             }
 

--- a/Sources/DynamicIsland/Views/Reply.swift
+++ b/Sources/DynamicIsland/Views/Reply.swift
@@ -30,8 +30,17 @@ struct PermissionActionButtons: View {
     @ObservedObject var stateManager: IslandStateManager
     let suggestedRule: PermissionRuleSuggestion?
     let eventID: UUID
+    let tty: String?
+
+    @AppStorage(clickToTerminalKey, store: dynamicIslandUserDefaults)
+    private var clickToTerminalEnabled = true
 
     private var expired: Bool { stateManager.currentEventExpired }
+
+    private var canJumpToTab: Bool {
+        guard !expired, clickToTerminalEnabled, let tty, !tty.isEmpty else { return false }
+        return TerminalActivator.hasRunningTerminal()
+    }
 
     var body: some View {
         VStack(spacing: 8) {
@@ -106,6 +115,29 @@ struct PermissionActionButtons: View {
                 .buttonStyle(.plain)
                 .disabled(expired)
                 .opacity(expired ? 0.5 : 1)
+            }
+
+            // Jump to the terminal tab that's awaiting this decision —
+            // gives the user a discoverable alternative to clicking the
+            // ear, which isn't obvious. Doesn't resolve the permission;
+            // user still has to come back and pick Allow/Deny.
+            if canJumpToTab, let tty {
+                Button(action: { TerminalActivator.activate(tty: tty) }) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "terminal")
+                            .font(.system(size: 11))
+                        Text("Jump to terminal tab")
+                            .font(.system(size: 11, weight: .medium))
+                    }
+                    .foregroundColor(.white.opacity(0.85))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 5)
+                    .background(
+                        RoundedRectangle(cornerRadius: 9)
+                            .fill(Color.white.opacity(0.08))
+                    )
+                }
+                .buttonStyle(.plain)
             }
 
             if expired {

--- a/Sources/DynamicIslandCore/EventDecoder.swift
+++ b/Sources/DynamicIslandCore/EventDecoder.swift
@@ -37,3 +37,20 @@ public func decodeSuggestedRuleFields(from json: [String: Any]) -> (toolName: St
     }
     return (toolName, ruleContent)
 }
+
+/// Strict allow-list for the `tty` field on event payloads. Returns the
+/// path verbatim only when it matches `/dev/ttys<digits>` or
+/// `/dev/pts/<digits>` — the two shapes macOS / Linux assign to
+/// pseudo-terminals. Anything else (relative paths, traversal,
+/// unrelated `/dev/` device nodes, non-strings) returns nil.
+///
+/// The value is interpolated into AppleScript source at click time
+/// (see `TerminalActivator`), so a permissive decoder would expose a
+/// shell-style injection surface to anyone able to POST `/event`. Keep
+/// this list narrow.
+public func decodeTTY(from raw: Any?) -> String? {
+    guard let s = raw as? String, !s.isEmpty, s.count <= 64 else { return nil }
+    let pattern = #"^/dev/(ttys[0-9]+|pts/[0-9]+)$"#
+    guard s.range(of: pattern, options: .regularExpression) != nil else { return nil }
+    return s
+}

--- a/Sources/IslandHookCore/HookPlan.swift
+++ b/Sources/IslandHookCore/HookPlan.swift
@@ -33,6 +33,13 @@ public struct HookPlan {
     /// `longPollResponse` and is mirrored into the `~/.claude/settings.json`
     /// Stop entry's `timeout` field on install.
     public let stopReplyTimeoutSeconds: TimeInterval
+    /// Controlling TTY of the Claude Code / Copilot / Codex process that
+    /// invoked this hook (e.g. `/dev/ttys003`). Forwarded into the event
+    /// payload via `decorate` so a click on the island can ask
+    /// `Terminal.app` / `iTerm2` to focus the matching tab without any
+    /// other correlation. Nil when the parent isn't attached to a TTY
+    /// (GUI launch, self-test) — callers fall back to no-op activate.
+    public let tty: String?
 
     public init(
         payload: [String: Any], source: String, event: String, tool: String,
@@ -42,7 +49,8 @@ public struct HookPlan {
         toolInput: [String: Any], copilotToolArgs: [String: Any],
         cpError: String?,
         inlineReplyEnabled: Bool = false,
-        stopReplyTimeoutSeconds: TimeInterval = StopReplyTimeoutSeconds
+        stopReplyTimeoutSeconds: TimeInterval = StopReplyTimeoutSeconds,
+        tty: String? = nil
     ) {
         self.payload = payload
         self.source = source
@@ -59,12 +67,20 @@ public struct HookPlan {
         self.cpError = cpError
         self.inlineReplyEnabled = inlineReplyEnabled
         self.stopReplyTimeoutSeconds = stopReplyTimeoutSeconds
+        self.tty = tty
     }
 }
 
 /// Parse a raw hook payload into a `HookPlan`, returning nil if the payload
 /// doesn't match any routable shape. Pure — no I/O.
-public func parseHookPlan(payload: [String: Any], env: [String: String] = [:]) -> HookPlan? {
+///
+/// `tty` is plumbed in by the hook binary (which runs `detectControllingTTY`)
+/// rather than discovered here, so this stays Foundation-only and unit-testable.
+public func parseHookPlan(
+    payload: [String: Any],
+    env: [String: String] = [:],
+    tty: String? = nil
+) -> HookPlan? {
     // SOURCE drives the project color:
     //   claude  → warm orange    copilot → GitHub violet    codex → OpenAI green
     // Override via ISLAND_SOURCE env var (Codex hook script should set this).
@@ -159,7 +175,8 @@ public func parseHookPlan(payload: [String: Any], env: [String: String] = [:]) -
         toolInput: toolInput, copilotToolArgs: copilotToolArgs,
         cpError: cpError,
         inlineReplyEnabled: env["CC_ISLAND_INLINE_REPLY"] == "1",
-        stopReplyTimeoutSeconds: stopReplyTimeoutSeconds
+        stopReplyTimeoutSeconds: stopReplyTimeoutSeconds,
+        tty: tty
     )
 }
 
@@ -182,6 +199,13 @@ extension HookPlan {
         // "user resolved on the terminal side" detection (#31 follow-up).
         if let sid = payload["session_id"] as? String, !sid.isEmpty {
             p["session_id"] = sid
+        }
+        // Carries the Claude Code process's controlling TTY so a click on
+        // the island can focus the matching Terminal.app / iTerm2 tab.
+        // Only set when the hook actually resolved one; the app side
+        // tolerates a missing field.
+        if let tty = tty, !tty.isEmpty {
+            p["tty"] = tty
         }
         return p
     }

--- a/Sources/IslandHookCore/TTYDetect.swift
+++ b/Sources/IslandHookCore/TTYDetect.swift
@@ -1,0 +1,54 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// Normalize raw `ps -o tty= -p <pid>` output into a `/dev/<name>` path.
+///
+/// `ps` writes the bare device name (e.g. `ttys003`) for processes attached to
+/// a controlling terminal, `?` or `??` for daemons, and an empty string when
+/// the pid doesn't exist. Returns nil for any non-tty answer so callers don't
+/// have to special-case them.
+public func parsePSTTYOutput(_ raw: String) -> String? {
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty, trimmed != "?", trimmed != "??" else { return nil }
+    if trimmed.hasPrefix("/dev/") { return trimmed }
+    return "/dev/\(trimmed)"
+}
+
+/// Resolve the controlling TTY of `parentPID` by shelling out to `ps`.
+///
+/// The hook's own stdio is piped from Claude Code, so `ttyname(0)` is useless
+/// here — we walk one hop up the process tree (`getppid()` by default) and
+/// ask `ps` for that parent's controlling terminal. The returned path is what
+/// `Terminal.app`/`iTerm2` expose as the `tty` of a tab/session, so a click
+/// on the island can find the right tab without any extra correlation.
+///
+/// Returns nil if `ps` is missing, fails, or the parent isn't attached to a
+/// terminal (e.g. Codex/Copilot launched from a GUI app, or self-test).
+public func detectControllingTTY(parentPID: Int32 = getppid()) -> String? {
+    let psPath = "/bin/ps"
+    guard FileManager.default.isExecutableFile(atPath: psPath) else { return nil }
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: psPath)
+    process.arguments = ["-o", "tty=", "-p", "\(parentPID)"]
+    let stdout = Pipe()
+    process.standardOutput = stdout
+    // Discard stderr so a noisy ps doesn't pollute the hook's stderr.
+    process.standardError = Pipe()
+
+    do {
+        try process.run()
+    } catch {
+        return nil
+    }
+    process.waitUntilExit()
+    guard process.terminationStatus == 0 else { return nil }
+
+    let data = stdout.fileHandleForReading.readDataToEndOfFile()
+    guard let raw = String(data: data, encoding: .utf8) else { return nil }
+    return parsePSTTYOutput(raw)
+}

--- a/Sources/island-hook/main.swift
+++ b/Sources/island-hook/main.swift
@@ -22,10 +22,17 @@ let eventID = UUID().uuidString.lowercased()
 // MARK: - Parse stdin
 
 let inputData = FileHandle.standardInput.readDataToEndOfFile()
+// Resolve the parent process's controlling TTY before parse so it rides
+// through `decorate` into every payload — see `HookPlan.tty`.
+let detectedTTY = detectControllingTTY()
 guard !inputData.isEmpty,
       let jsonAny = try? JSONSerialization.jsonObject(with: inputData),
       let payload = jsonAny as? [String: Any],
-      let plan = parseHookPlan(payload: payload, env: ProcessInfo.processInfo.environment)
+      let plan = parseHookPlan(
+        payload: payload,
+        env: ProcessInfo.processInfo.environment,
+        tty: detectedTTY
+      )
 else { exit(0) }
 
 // MARK: - I/O helpers

--- a/Tests/DynamicIslandCoreTests/EventDecoderTests.swift
+++ b/Tests/DynamicIslandCoreTests/EventDecoderTests.swift
@@ -103,4 +103,61 @@ final class EventDecoderTests: XCTestCase {
         ]
         XCTAssertNil(decodeSuggestedRuleFields(from: json))
     }
+
+    // MARK: - decodeTTY
+
+    func testTTY_acceptsTtysShape() {
+        XCTAssertEqual(decodeTTY(from: "/dev/ttys003"), "/dev/ttys003")
+        XCTAssertEqual(decodeTTY(from: "/dev/ttys123"), "/dev/ttys123")
+    }
+
+    func testTTY_acceptsPtsShape() {
+        XCTAssertEqual(decodeTTY(from: "/dev/pts/3"), "/dev/pts/3")
+        XCTAssertEqual(decodeTTY(from: "/dev/pts/42"), "/dev/pts/42")
+    }
+
+    func testTTY_nilForRelativePath() {
+        // Relative paths bypass the `/dev/` allow-list — always reject.
+        XCTAssertNil(decodeTTY(from: "ttys003"))
+    }
+
+    func testTTY_nilForArbitraryDevicePath() {
+        // Other /dev/ entries (disks, console) must not be focusable —
+        // AppleScript would happily interpolate them.
+        XCTAssertNil(decodeTTY(from: "/dev/null"))
+        XCTAssertNil(decodeTTY(from: "/dev/tty"))
+        XCTAssertNil(decodeTTY(from: "/dev/console"))
+        XCTAssertNil(decodeTTY(from: "/dev/disk0"))
+    }
+
+    func testTTY_nilForInjectionAttempt() {
+        // Strict regex rejects newlines / quotes / shell metacharacters
+        // even inside /dev/ttys-prefixed strings.
+        XCTAssertNil(decodeTTY(from: "/dev/ttys003\"; do shell script \"rm\""))
+        XCTAssertNil(decodeTTY(from: "/dev/ttys003\nactivate"))
+        XCTAssertNil(decodeTTY(from: "/dev/ttys003 && evil"))
+        XCTAssertNil(decodeTTY(from: "/dev/../etc/passwd"))
+    }
+
+    func testTTY_nilForMissing() {
+        XCTAssertNil(decodeTTY(from: nil))
+    }
+
+    func testTTY_nilForNonString() {
+        XCTAssertNil(decodeTTY(from: 42))
+        XCTAssertNil(decodeTTY(from: true))
+        XCTAssertNil(decodeTTY(from: ["/dev/ttys003"]))
+    }
+
+    func testTTY_nilForEmpty() {
+        XCTAssertNil(decodeTTY(from: ""))
+    }
+
+    func testTTY_nilForOversize() {
+        // Pathological 64+ char path — bound the length so we don't
+        // dump arbitrary bytes into AppleScript even if the regex
+        // would otherwise match.
+        let huge = "/dev/ttys" + String(repeating: "9", count: 200)
+        XCTAssertNil(decodeTTY(from: huge))
+    }
 }

--- a/Tests/IslandHookCoreTests/TTYDetectTests.swift
+++ b/Tests/IslandHookCoreTests/TTYDetectTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import IslandHookCore
+
+final class TTYDetectTests: XCTestCase {
+
+    // MARK: - parsePSTTYOutput
+
+    func testPSTTY_normalizesShortName() {
+        XCTAssertEqual(parsePSTTYOutput("ttys003"), "/dev/ttys003")
+    }
+
+    func testPSTTY_passesAbsolutePathThrough() {
+        XCTAssertEqual(parsePSTTYOutput("/dev/ttys003"), "/dev/ttys003")
+    }
+
+    func testPSTTY_trimsWhitespaceAndNewlines() {
+        XCTAssertEqual(parsePSTTYOutput("  ttys003\n"), "/dev/ttys003")
+        XCTAssertEqual(parsePSTTYOutput("\tttys003 "), "/dev/ttys003")
+    }
+
+    func testPSTTY_nilForQuestionMark() {
+        // ps prints "?" or "??" when the process has no controlling tty
+        // (daemons, GUI launches). We don't want to forward bogus device
+        // names to the click handler.
+        XCTAssertNil(parsePSTTYOutput("?"))
+        XCTAssertNil(parsePSTTYOutput("??"))
+        XCTAssertNil(parsePSTTYOutput(" ? "))
+    }
+
+    func testPSTTY_nilForEmpty() {
+        XCTAssertNil(parsePSTTYOutput(""))
+        XCTAssertNil(parsePSTTYOutput("   "))
+        XCTAssertNil(parsePSTTYOutput("\n\n"))
+    }
+
+    func testPSTTY_handlesPtsStyle() {
+        // Linux-flavoured tty paths still parse; the AppleScript side
+        // simply won't match them on macOS.
+        XCTAssertEqual(parsePSTTYOutput("pts/3"), "/dev/pts/3")
+    }
+
+    // MARK: - HookPlan integration
+
+    func testDecorate_emitsTTYWhenSet() {
+        guard let plan = parseHookPlan(
+            payload: [
+                "hook_event_name": "PreToolUse", "tool_name": "Bash",
+                "tool_input": ["command": "ls"],
+                "cwd": "/tmp/demo",
+            ],
+            tty: "/dev/ttys003"
+        ) else {
+            XCTFail("payload should parse")
+            return
+        }
+        let body = plan.decorate(["title": "x"])
+        XCTAssertEqual(body["tty"] as? String, "/dev/ttys003")
+    }
+
+    func testDecorate_omitsTTYWhenNil() {
+        guard let plan = parseHookPlan(
+            payload: [
+                "hook_event_name": "PreToolUse", "tool_name": "Bash",
+                "tool_input": ["command": "ls"],
+                "cwd": "/tmp/demo",
+            ]
+        ) else {
+            XCTFail("payload should parse")
+            return
+        }
+        let body = plan.decorate(["title": "x"])
+        XCTAssertNil(body["tty"])
+    }
+
+    func testDecorate_omitsTTYWhenEmptyString() {
+        guard let plan = parseHookPlan(
+            payload: [
+                "hook_event_name": "PreToolUse", "tool_name": "Bash",
+                "tool_input": ["command": "ls"],
+                "cwd": "/tmp/demo",
+            ],
+            tty: ""
+        ) else {
+            XCTFail("payload should parse")
+            return
+        }
+        let body = plan.decorate(["title": "x"])
+        XCTAssertNil(body["tty"])
+    }
+}


### PR DESCRIPTION
## Summary

A click on the compact ear / capsule now focuses the Terminal.app or iTerm2 tab running the matching Claude Code / Copilot / Codex session, instead of just expanding the event. Off-switch lives under **Settings → General → Click behaviour**.

### How it works

- **Hook side** (`IslandHookCore/TTYDetect.swift`): each hook invocation shells out to `ps -o tty= -p <ppid>` to resolve the controlling TTY of the parent process (the Claude Code CLI), then plumbs it through `parseHookPlan` → `HookPlan.decorate` so every outbound event payload carries a `tty` field.
- **App side** (`DynamicIslandCore/EventDecoder.swift`): a strict regex allow-list (`/dev/ttys<N>` or `/dev/pts/<N>`, length ≤ 64) gates the value before it ever reaches AppleScript — keeps the interpolation in `TerminalActivator` from being a shell-injection sink for anyone able to POST `/event`.
- **Tap dispatch**: `IslandStateManager.handleCompactTap()` is the new single entry point shared by `LeftEarView` / `RightEarView` / `CompactPillView`. Pulsing events (action / reminder) keep their existing dismiss behaviour because their decision UI lives on the island; everything else with a tty triggers `TerminalActivator.activate(tty:)` and dismisses, falling back to the legacy expand path otherwise.
- **Activator** (`DynamicIsland/TerminalActivator.swift`): runs an `osascript` against Terminal.app first (which exposes `tty` directly on each tab), then iTerm2 (which exposes it on each session). When neither matches, it `NSWorkspace.activate`s the first registered terminal app it finds (Ghostty, WezTerm, Warp, Hyper, kitty, Alacritty) so the user at least lands somewhere familiar.

### Settings

New `clickToTerminalEnabled` UserDefault, default **on**, registered in `App.applicationDidFinishLaunching` and exposed via a Settings → General → "Click behaviour" toggle. Toggling it off restores the pre-PR expand-on-tap behaviour without any reinstall.

## Test plan

- [ ] `swift test` passes (new tests: `TTYDetectTests`, `EventDecoderTests.testTTY_*`)
- [ ] Click on a `Bash` / `Edit` / `Read` ear with Terminal.app running → tab is focused, island dismisses
- [ ] Click on the same with iTerm2 running → session is selected, iTerm activates
- [ ] Click on a `PermissionRequest` (action) event → island dismisses, terminal is **not** activated
- [ ] Click on a `Stop` reminder with quick replies → island dismisses, terminal is **not** activated
- [ ] Self-test from Settings → Diagnostics still works (parent has no controlling tty → field omitted, click falls back to expand)
- [ ] Toggle Settings → General → "Click island to focus terminal tab" off → ear taps revert to expand
- [ ] First terminal activation triggers macOS Automation permission prompt; subsequent clicks work without prompting

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWHjyxGGU5S7hGxzurmcf5)_