### PR TITLE
fix(capsule): make the whole compact pill tappable

### DIFF
--- a/Sources/DynamicIsland/Views/Capsule.swift
+++ b/Sources/DynamicIsland/Views/Capsule.swift
@@ -91,6 +91,10 @@ struct CompactPillView: View {
                 .overlay(Capsule().strokeBorder(event.style.glowColor, lineWidth: 1))
                 .shadow(color: event.style.glowColor, radius: 8, x: 0, y: 2)
         )
+        // Make the whole pill tappable: `.background` content is excluded from
+        // hit-testing, so without this only the text glyphs registered taps —
+        // the rounded ends and padding were dead zones.
+        .contentShape(Capsule())
         .onTapGesture { stateManager.expand() }
         .onAppear { appeared = true }
         .onDisappear { appeared = false }


### PR DESCRIPTION
## Summary

On a non-notch display the island renders as `CompactPillView`. Its background is drawn with `.background(Capsule()…)`, and SwiftUI **excludes `.background` content from hit-testing**. Without a `.contentShape`, only the text glyphs registered taps — the capsule's rounded ends and horizontal padding were **dead zones**, so clicking there did nothing instead of expanding the event.

This was easy to hit in practice: the visible pill looks fully clickable, but ~⅓ of its width (the rounded caps + padding) silently ignored taps.

## Fix

Add `.contentShape(Capsule())` before `.onTapGesture` so the entire visible pill is the tap target. No behaviour change beyond the previously-dead regions now responding.

```diff
                 .shadow(color: event.style.glowColor, radius: 8, x: 0, y: 2)
         )
+        .contentShape(Capsule())
         .onTapGesture { stateManager.expand() }
```

## Test plan

- [x] `swift test` — 227 tests pass
- [x] Build clean (`swift build`)
- [x] Verified live: before the fix, tapping the pill's rounded ends did nothing; after, the whole pill responds. (Found while testing the capsule on a non-notch display.)

Notes: the notch ears are unaffected — they use an opaque `LeftEarShape/RightEarShape().fill()` as real content, which is already fully hittable. This only affects the fallback pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)